### PR TITLE
CKS conformance for v1.33 and v1.34

### DIFF
--- a/v1.33/cks/PRODUCT.yaml
+++ b/v1.33/cks/PRODUCT.yaml
@@ -1,7 +1,7 @@
 metadata:
-  kubernetesVersion: v1.34
+  kubernetesVersion: v1.33
   platformName: CoreWeave Kubernetes Service (CKS)
-  platformVersion: v1beta1
+  platformVersion: v1.33
   vendorName: CoreWeave
   website_url: https://www.coreweave.com/products/coreweave-kubernetes-service
   repo_url: https://github.com/yoyo.dyne/turbo-encabulator

--- a/v1.34/cks/PRODUCT.yaml
+++ b/v1.34/cks/PRODUCT.yaml
@@ -1,7 +1,7 @@
 metadata:
   kubernetesVersion: v1.34
   platformName: CoreWeave Kubernetes Service (CKS)
-  platformVersion: v1beta1
+  platformVersion: v1.34
   vendorName: CoreWeave
   website_url: https://www.coreweave.com/products/coreweave-kubernetes-service
   repo_url: https://github.com/yoyo.dyne/turbo-encabulator


### PR DESCRIPTION
This PR provides the necessary evidence and documentation for AI Conformance for both Kubernetes v1.33 and v1.34 of the CKS Platform.