### PR TITLE
rename repo to k8s-ai-conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ If your company provides a platform for Artificial Intelligence and Machine Lear
 
 ## Prepare
 
-Learn about the [certification requirements](https://github.com/cncf/ai-conformance/blob/master/terms-conditions/Certified_AI_Platform.md) and technical instructions to prepare your product for certification.
+Learn about the [certification requirements](https://github.com/cncf/k8s-ai-conformance/blob/master/terms-conditions/Certified_AI_Platform.md) and technical instructions to prepare your product for certification.
 
 ## PR Submit
 
-Please check the [instructions](https://github.com/cncf/ai-conformance/blob/master/instructions.md#contents-of-the-pr) for details about how to prepare your PR.
+Please check the [instructions](https://github.com/cncf/k8s-ai-conformance/blob/master/instructions.md#contents-of-the-pr) for details about how to prepare your PR.
 Also, note that any submission made to this repo will need to first pass a number of checks that are verified by the [verify conformance bot](#verify-conformance-bot-coming-soon) before its reviewed by the CNCF.
 
 ## Helpful Resources

--- a/instructions.md
+++ b/instructions.md
@@ -7,7 +7,7 @@ The standard set of conformance requirements are defined in `docs/AiConformance-
 ## Uploading
 
 Prepare a PR to
-[https://github.com/cncf/ai-conformance](https://github.com/cncf/ai-conformance).
+[https://github.com/cncf/k8s-ai-conformance](https://github.com/cncf/k8s-ai-conformance).
 Here are [directions](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork) to
 prepare a pull request from a fork.
 In the descriptions below, `X.Y` refers to the kubernetes major and minor
@@ -81,7 +81,7 @@ If you don't see a response within 10 business days, please contact conformance@
 
 If you have problems certifying that you feel are an issue with the conformance
 program itself (and not just your own implementation), you can file an issue in
-the [repository](https://github.com/cncf/ai-conformance). Questions and
+the [repository](https://github.com/cncf/k8s-ai-conformance). Questions and
 comments can also be sent to the working group's
 [mailing list and slack channel](README-WG.md).
 [WG AI Conformance](https://github.com/kubernetes/community/tree/master/wg-ai-conformance)

--- a/terms-conditions/Certified_AI_Platform.md
+++ b/terms-conditions/Certified_AI_Platform.md
@@ -20,7 +20,7 @@ By submitting one or more Applicant Platforms to be certified as a Conformant Pl
   
 * "**Conformance Checklist**" means any specific instance of the Conformance Checklist Template submitted by a Participant as a pull request to the Program Repository.
   
-* "**Conformance Checklist Template"** means the current version of the YAML file template available at [https://github.com/cncf/ai-conformance/tree/main/docs](https://github.com/cncf/ai-conformance/tree/main/docs), which defines the criteria that a Platform must meet in order to qualify as a Conformant Platform.
+* "**Conformance Checklist Template"** means the current version of the YAML file template available at [https://github.com/cncf/k8s-ai-conformance/tree/main/docs](https://github.com/cncf/k8s-ai-conformance/tree/main/docs), which defines the criteria that a Platform must meet in order to qualify as a Conformant Platform.
   
 * "**Conformant Platform**" means a specific version of Platform that has met all Program requirements and has been approved by CNCF.
   
@@ -35,9 +35,9 @@ By submitting one or more Applicant Platforms to be certified as a Conformant Pl
   
 * "**Program Materials**" means the Program Repository, and content and materials contained therein outlining the goals, scope, requirements, and process of the Conformance Program. The Program Materials include, without limitation, the Conformance Checklist Template, and Submission Instructions.
   
-* **"Program Repository"** means the repository for the Conformance Program available at [https://github.com/cncf/ai-conformance](https://github.com/cncf/ai-conformance).
+* **"Program Repository"** means the repository for the Conformance Program available at [https://github.com/cncf/k8s-ai-conformance](https://github.com/cncf/k8s-ai-conformance).
   
-* "**Submission Instructions**" means the instructions for submitting a Platform for certification as a Conformant Platform, available at [https://github.com/cncf/ai-conformance/blob/main/instructions.md](https://github.com/cncf/ai-conformance/blob/main/instructions.md).
+* "**Submission Instructions**" means the instructions for submitting a Platform for certification as a Conformant Platform, available at [https://github.com/cncf/k8s-ai-conformance/blob/main/instructions.md](https://github.com/cncf/k8s-ai-conformance/blob/main/instructions.md).
   
 * "**Terms**" means these terms and conditions, together with all documents incorporated herein.
 


### PR DESCRIPTION
@janetkuo @mfahlandt 

cc @caniszczyk @joannalee333 for awareness

Existing links to cncf/ai-conformance will still work, just redirect (for now)