### PR TITLE
Added 1.35 AI Conformance Requirements

### DIFF
--- a/docs/AIConformance-1.35.yaml
+++ b/docs/AIConformance-1.35.yaml
@@ -29,7 +29,7 @@ spec:
       evidence: []
       notes: ""
     - id: gpu_sharing
-      description: "For accelerators that support static GPU sharing, provide well-defined mechanisms for at least one GPU sharing strategy to improve utilization for workloads that do not require a full dedicated GPU. If hardware-level partitioning is supported, then these fractional GPU resources should be exposed as schedulable resources. If software-based sharing (e.g. time-slicing) is supported, then oversubscription of GPUs should be allowed. Forward-looking: Once the accelerator supports static GPU sharing as part of DRA, then the platform should use the DRA mechanism for static GPU sharing. Once the accelerator supports dynamic GPU sharing as part of DRA and the partitionable devices feature is GA, then the platform should use the DRA mechanism for dynamic GPU sharing."
+      description: "For accelerators that support static GPU sharing, provide well-defined mechanisms for at least one GPU sharing strategy to improve utilization for workloads that do not require a full dedicated GPU. If hardware-level partitioning is supported, then these fractional GPU resources should be exposed as schedulable resources. If software-based sharing (e.g. time-slicing) is supported, then oversubscription of GPUs should be allowed. Forward-looking: Once the accelerator supports static GPU sharing as part of DRA, the platform should expose the DRA mechanism to allow users to leverage static GPU sharing. Once the accelerator supports dynamic GPU sharing as part of DRA and the partitionable devices feature is GA, the platform should expose the DRA mechanism to allow users to leverage dynamic GPU sharing."
       level: SHOULD
       status: ""
       evidence: []


### PR DESCRIPTION
3 more `SHOULD` requirements under `accelerators` are added in 1.35. 

For more information about each additional SHOULD requirement:
* driver_runtime_management: https://github.com/kubernetes-sigs/wg-ai-conformance/tree/main/kars/0001-accelerator-driver-runtime-management
* gpu_sharing: https://github.com/kubernetes-sigs/wg-ai-conformance/tree/main/kars/0003-gpu-sharing
* virtualized_accelerator: https://github.com/kubernetes-sigs/wg-ai-conformance/tree/main/kars/0004-virtualized-accelerators