### PR TITLE
docs: improve README clarity and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For detailed instructions on what to include, see [instructions.md](instructions
 
 ### For Contributors
 
-You don't need to be a vendor to help shape this standard. The program is being developed in the open by the Kubernetes community.
+The program is a community-led effort to establish a vendor-neutral baseline for AI portability. We welcome participation from all stakeholders, including end users, to ensure the standard remains independent and effective.
 
 #### Ways to contribute
 


### PR DESCRIPTION
This PR improves the README to be clearer and more welcoming for first-time visitors.

## Changes

- **Added quick start guidance** — a single sentence after the quick links so visitors immediately know where to go (vendors vs contributors)
- **Made the intro more conversational** — grounded the "why this matters" section in real AI/ML cluster pain points instead of abstract goals
- **Expanded workload descriptions** — training, inference, and agentic workloads now read like real-world examples
- **Minor wording tweaks** — e.g. "Today" instead of "As of 2025" for the self-assessment note

No structural or link changes.