### PR TITLE
NVIDIA NIM on EKS AI Conformance for v1.35

### DIFF
--- a/v1.35/nvidia-nim-eks/PRODUCT.yaml
+++ b/v1.35/nvidia-nim-eks/PRODUCT.yaml
@@ -1,0 +1,249 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metadata:
+  kubernetesVersion: v1.35
+  platformName: "NVIDIA NIM on EKS"
+  platformVersion: "1.8.3"
+  vendorName: "NVIDIA"
+  websiteUrl: "https://developer.nvidia.com/nim"
+  repoUrl: "https://github.com/NVIDIA/k8s-nim-operator"
+  documentationUrl: "https://docs.nvidia.com/nim/large-language-models/latest/deploy-helm.html"
+  productLogoUrl: "https://raw.githubusercontent.com/cncf/landscape/master/hosted_logos/nvidia-member.svg"
+  description: >-
+    NVIDIA NIM on EKS is a Kubernetes-based AI inference platform that deploys
+    and manages NVIDIA NIM microservices on Amazon EKS with GPU scheduling,
+    autoscaling, and Gateway API integration.
+  contactEmailAddress: "yuanchen97@gmail.com"
+  # NVIDIA NIM on EKS is not a Kubernetes distribution — it is an AI inference
+  # platform deployed on top of conformant Amazon EKS. Per CNCF AI Conformance
+  # guidelines, we reference the underlying Kubernetes distribution's conformance
+  # entry to establish that the base platform is already K8s conformant.
+  # This submission certifies the AI capabilities layered on top of EKS.
+  k8sConformanceUrl: "https://github.com/cncf/k8s-conformance/tree/master/v1.35/eks"
+
+spec:
+  accelerators:
+    - id: dra_support
+      description: "Support Dynamic Resource Allocation (DRA) APIs to enable more flexible and fine-grained resource requests beyond simple counts."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/dra-support.md"
+      notes: >-
+        DRA API (resource.k8s.io/v1) is enabled with DeviceClass, ResourceClaim,
+        ResourceClaimTemplate, and ResourceSlice resources available. The NVIDIA
+        DRA driver runs as controller and kubelet-plugin pods, advertising
+        individual H100 GPU devices via ResourceSlices with unique UUIDs, PCI
+        bus IDs, CUDA compute capability, and memory capacity. GPU allocation to
+        pods is mediated through ResourceClaims.
+    - id: driver_runtime_management
+      description: >-
+        Provide a verifiable mechanism for ensuring that compatible accelerator
+        drivers and corresponding container runtime configurations are correctly
+        installed and maintained on nodes with accelerators. Once the accelerator
+        supports exposing driver and runtime version information as part of DRA,
+        then the platform should use the DRA mechanism for verification.
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/dra-support.md"
+      notes: >-
+        GPU Operator manages the full driver and runtime lifecycle: driver
+        installation, container toolkit configuration, device plugin, and DRA
+        driver. The nvidia-operator-validator pod verifies driver, toolkit, and
+        device-plugin health on each GPU node. DRA ResourceSlices expose driver
+        version and device attributes for verification.
+    - id: gpu_sharing
+      description: >-
+        For accelerators that support static GPU sharing, provide well-defined
+        mechanisms for at least one GPU sharing strategy to improve utilization
+        for workloads that do not require a full dedicated GPU. If
+        hardware-level partitioning is supported, then these fractional GPU
+        resources should be exposed as schedulable resources. If software-based
+        sharing (e.g. time-slicing) is supported, then oversubscription of GPUs
+        should be allowed. Forward-looking: Once the accelerator supports
+        static GPU sharing as part of DRA, the platform should expose the DRA
+        mechanism to allow users to leverage static GPU sharing. Once the
+        accelerator supports dynamic GPU sharing as part of DRA and the
+        partitionable devices feature is GA, the platform should expose the DRA
+        mechanism to allow users to leverage dynamic GPU sharing.
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html"
+      notes: >-
+        GPU Operator supports MIG (Multi-Instance GPU) partitioning for hardware-level
+        GPU sharing on supported accelerators (A100, H100). MIG profiles are managed
+        via the nvidia-mig-manager DaemonSet. Time-slicing is also supported for
+        software-based GPU sharing across workloads.
+    - id: virtualized_accelerator
+      description: >-
+        For accelerators that support virtualized accelerator technologies
+        (e.g. vGPU), provide well-defined mechanisms for these to be exposed
+        and managed, maintaining consistency with physical fractional GPUs.
+        Forward-looking: Once the accelerator supports virtualized accelerator
+        technologies as part of DRA, then the platform should use the DRA
+        mechanism.
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html"
+      notes: >-
+        GPU Operator supports vGPU deployments where the hypervisor exposes
+        virtual GPU devices to Kubernetes nodes. vGPU resources are managed
+        through the same device plugin and DRA framework as physical GPUs,
+        maintaining a consistent management experience.
+  networking:
+    - id: ai_inference
+      description: >-
+        Support the Kubernetes Gateway API with an implementation for advanced
+        traffic management for inference services, which enables capabilities
+        like weighted traffic splitting, header-based routing (for OpenAI
+        protocol headers), and optional integration with service meshes.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/inference-gateway.md"
+      notes: >-
+        kgateway controller is deployed with full Gateway API CRD support
+        (GatewayClass, Gateway, HTTPRoute, GRPCRoute, ReferenceGrant). Inference
+        extension CRDs (InferencePool, InferenceModelRewrite,
+        InferenceObjective) are registered. An active inference gateway is
+        verified with GatewayClass Accepted=True and Gateway Programmed=True
+        conditions.
+  schedulingOrchestration:
+    - id: gang_scheduling
+      description: >-
+        The platform must allow for the installation and successful operation of
+        at least one gang scheduling solution that ensures all-or-nothing
+        scheduling for distributed AI workloads (e.g. Kueue, Volcano, etc.) To
+        be conformant, the vendor must demonstrate that their platform can
+        successfully run at least one such solution.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/gang-scheduling.md"
+      notes: >-
+        KAI Scheduler is deployed with operator, scheduler, admission
+        controller, pod-grouper, and queue-controller components. PodGroup CRD
+        (scheduling.run.ai) is registered. Gang scheduling is verified by
+        deploying a PodGroup with minMember=2 and two GPU pods, demonstrating
+        all-or-nothing atomic scheduling.
+    - id: cluster_autoscaling
+      description: >-
+        If the platform provides a cluster autoscaler or an equivalent
+        mechanism, it must be able to scale up/down node groups containing
+        specific accelerator types based on pending pods requesting those
+        accelerators.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/cluster-autoscaling.md"
+      notes: >-
+        Demonstrated on EKS with a GPU Auto Scaling Group (p5.48xlarge, 8x H100
+        per node) tagged for Cluster Autoscaler discovery. The platform supports
+        scaling GPU nodes based on pending pod demand.
+    - id: pod_autoscaling
+      description: >-
+        If the platform supports the HorizontalPodAutoscaler, it must function
+        correctly for pods utilizing accelerators. This includes the ability to
+        scale these Pods based on custom metrics relevant to AI/ML workloads.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/pod-autoscaling.md"
+      notes: >-
+        Prometheus adapter exposes GPU custom metrics (gpu_utilization,
+        gpu_memory_used, gpu_power_usage) via the Kubernetes custom metrics API.
+        HPA is configured to target gpu_utilization at 50% threshold. Under GPU
+        stress testing (CUDA N-Body Simulation), HPA successfully scales
+        replicas from 1 to 2 pods when utilization exceeds the target, and
+        scales back down when GPU load is removed.
+  observability:
+    - id: accelerator_metrics
+      description: >-
+        For supported accelerator types, the platform must allow for the
+        installation and successful operation of at least one accelerator
+        metrics solution that exposes fine-grained performance metrics via a
+        standardized, machine-readable metrics endpoint. This must include a
+        core set of metrics for per-accelerator utilization and memory usage.
+        Additionally, other relevant metrics such as temperature, power draw,
+        and interconnect bandwidth should be exposed if the underlying hardware
+        or virtualization layer makes them available. The list of metrics should
+        align with emerging standards, such as OpenTelemetry metrics, to ensure
+        interoperability. The platform may provide a managed solution, but this
+        is not required for conformance.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/accelerator-metrics.md"
+      notes: >-
+        DCGM Exporter runs on GPU nodes exposing metrics at :9400/metrics in
+        Prometheus format. Per-GPU metrics include utilization, memory usage,
+        temperature (26-31C), and power draw (66-115W). Metrics include
+        pod/namespace/container labels for per-workload attribution. Prometheus
+        actively scrapes DCGM metrics via ServiceMonitor.
+    - id: ai_service_metrics
+      description: >-
+        Provide a monitoring system capable of discovering and collecting
+        metrics from workloads that expose them in a standard format (e.g.
+        Prometheus exposition format). This ensures easy integration for
+        collecting key metrics from common AI frameworks and servers.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/ai-service-metrics.md"
+      notes: >-
+        NVIDIA NIM inference microservice exposes Prometheus-format metrics at
+        /v1/metrics including token throughput (prompt_tokens_total,
+        generation_tokens_total), request latency (time_to_first_token_seconds,
+        time_per_output_token_seconds), and model request counts. Prometheus
+        and prometheus-adapter are deployed for metrics collection and bridging
+        to the Kubernetes custom metrics API.
+  security:
+    - id: secure_accelerator_access
+      description: >-
+        Ensure that access to accelerators from within containers is properly
+        isolated and mediated by the Kubernetes resource management framework
+        (device plugin or DRA) and container runtime, preventing unauthorized
+        access or interference between workloads.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/secure-accelerator-access.md"
+      notes: >-
+        GPU Operator manages all GPU lifecycle components (driver, device-plugin,
+        DCGM, toolkit, validator, MIG manager). 8x H100 GPUs are individually
+        advertised via ResourceSlices with DRA. Pod volumes contain only
+        kube-api-access projected tokens — no hostPath mounts to /dev/nvidia
+        devices. Device isolation is verified: a test pod requesting 1 GPU sees
+        only the single allocated device.
+  operator:
+    - id: robust_controller
+      description: >-
+        The platform must prove that at least one complex AI operator with a
+        CRD (e.g., Ray, Kubeflow) can be installed and functions reliably. This
+        includes verifying that the operator's pods run correctly, its webhooks
+        are operational, and its custom resources can be reconciled.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/robust-operator.md"
+      notes: >-
+        NVIDIA NIM Operator validated: 9 CRDs (NIMService, NIMCache, NIMPipeline,
+        NIMBuild, NemoCustomizer, NemoDatastore, NemoEntityStore, NemoEvaluator,
+        NemoGuardrail), admission controller with webhook rejection test (invalid
+        NIMService correctly denied), NIMService CR reconciled into running
+        inference pod serving Llama 3.2 1B on H100 GPU.

--- a/v1.35/nvidia-nim-eks/README.md
+++ b/v1.35/nvidia-nim-eks/README.md
@@ -1,0 +1,25 @@
+# NVIDIA NIM on EKS
+
+[NVIDIA NIM](https://developer.nvidia.com/nim) on EKS is a Kubernetes-based AI inference platform that deploys and manages NVIDIA NIM microservices on Amazon EKS with GPU scheduling, autoscaling, and Gateway API integration. NIM microservice lifecycle is managed by the [NIM Operator](https://github.com/NVIDIA/k8s-nim-operator).
+
+## Conformance Submission
+
+- [PRODUCT.yaml](PRODUCT.yaml)
+
+## Evidence
+
+Evidence was collected on an EKS v1.35 cluster with NVIDIA H100 80GB HBM3 GPUs running NIM inference workloads. Full evidence is hosted in the [AICR repository](https://github.com/NVIDIA/aicr/tree/main/docs/conformance/cncf/v1.35/nim-eks/evidence).
+
+| # | Requirement | Feature | Result | Evidence |
+|---|-------------|---------|--------|----------|
+| 1 | `dra_support` | Dynamic Resource Allocation | PASS | [dra-support.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/dra-support.md) |
+| 2 | `gang_scheduling` | Gang Scheduling (KAI Scheduler) | PASS | [gang-scheduling.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/gang-scheduling.md) |
+| 3 | `secure_accelerator_access` | Secure Accelerator Access | PASS | [secure-accelerator-access.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/secure-accelerator-access.md) |
+| 4 | `accelerator_metrics` | Accelerator Metrics (DCGM Exporter) | PASS | [accelerator-metrics.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/accelerator-metrics.md) |
+| 5 | `ai_service_metrics` | AI Service Metrics (NIM Inference) | PASS | [ai-service-metrics.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/ai-service-metrics.md) |
+| 6 | `ai_inference` | Inference API Gateway (kgateway) | PASS | [inference-gateway.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/inference-gateway.md) |
+| 7 | `robust_controller` | Robust AI Operator (NIM Operator) | PASS | [robust-operator.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/robust-operator.md) |
+| 8 | `pod_autoscaling` | Pod Autoscaling (HPA + GPU Metrics) | PASS | [pod-autoscaling.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/pod-autoscaling.md) |
+| 9 | `cluster_autoscaling` | Cluster Autoscaling | PASS | [cluster-autoscaling.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/cluster-autoscaling.md) |
+
+All 9 MUST conformance requirement IDs are **Implemented**. 3 SHOULD requirements (`driver_runtime_management`, `gpu_sharing`, `virtualized_accelerator`) are also Implemented.


### PR DESCRIPTION
### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Please confirm that the company or organization submitting a platform for certification accepts and agrees to the [Certified Kubernetes AI Platform Conformance Program Terms and Conditions](https://github.com/cncf/k8s-ai-conformance/blob/main/terms-conditions/Certified_AI_Platform.md).

* [x] Did you include the product/project logo in SVG, EPS or AI format?

* [x] Does your logo clearly state the name of your product and follow the participant logo [guidelines](https://github.com/cncf/landscape#logos)?

* [x] If your product/project is open source, did you include the `repoUrl`?

For a full list of requirements, please refer to these sections of the docs: [Contents of the PR](https://github.com/cncf/k8s-ai-conformance/blob/main/instructions.md#contents-of-the-pr), and [Requirements](https://github.com/cncf/k8s-ai-conformance/blob/main/instructions.md#requirements).

---

## NVIDIA NIM on EKS

> **Reworked based on WG feedback:** This PR was originally submitted as AICR (a configuration tool). Per feedback from @ritazh and @jackfrancis ([Slack thread](https://kubernetes.slack.com/archives/C09813W8DC2/p1774975374591599?thread_ts=1774363606.075179&cid=C09813W8DC2)), the WG requires certifying a **product** on a Kubernetes platform, not standalone tooling. We've reworked the submission to certify **NVIDIA NIM on EKS** — an AI inference product deployed on Amazon EKS.

[NVIDIA NIM](https://developer.nvidia.com/nim) on EKS is a Kubernetes-based AI inference platform that deploys and manages NVIDIA NIM microservices on Amazon EKS with GPU scheduling, autoscaling, and Gateway API integration. NIM microservice lifecycle is managed by the [NIM Operator](https://github.com/NVIDIA/k8s-nim-operator).

**Key distinction:** NIM is an AI inference product, not configuration tooling. [AICR](https://github.com/NVIDIA/aicr) serves as the deployment and validation tooling (similar to how [sonobuoy](https://sonobuoy.io/) is used for K8s conformance), while NIM is the certified product. No existing conformant platform needs to adopt AICR — this is NVIDIA certifying its own product on EKS.

## Conformance Evidence

All **9 MUST** requirements pass, plus 3 SHOULD requirements are implemented:

| # | Requirement | Feature | Result |
|---|-------------|---------|--------|
| 1 | `dra_support` | Dynamic Resource Allocation | PASS |
| 2 | `gang_scheduling` | Gang Scheduling (KAI Scheduler) | PASS |
| 3 | `secure_accelerator_access` | Secure Accelerator Access | PASS |
| 4 | `accelerator_metrics` | Accelerator Metrics (DCGM Exporter) | PASS |
| 5 | `ai_service_metrics` | AI Service Metrics (NIM Inference) | PASS |
| 6 | `ai_inference` | Inference API Gateway (kgateway) | PASS |
| 7 | `robust_controller` | Robust AI Operator (NIM Operator) | PASS |
| 8 | `pod_autoscaling` | Pod Autoscaling (HPA + GPU Metrics) | PASS |
| 9 | `cluster_autoscaling` | Cluster Autoscaling | PASS |

Evidence was collected on an EKS v1.35 cluster with NVIDIA H100 80GB HBM3 GPUs running NIM inference workloads (Llama 3.2 1B via NIMService CR).

## How this addresses prior feedback

**@ritazh — "certify a product, not tooling":**
NIM is the product being certified. AICR is the validation tooling, not the submission target. This follows the same pattern as other submissions where the certified product is a configured platform, not the tooling used to configure it.

**@jackfrancis — "AICR is not a K8s cluster distro or platform":**
Correct — and we are no longer certifying AICR. NIM on EKS is the product: an AI inference platform that uses the NIM Operator to manage NIM microservice lifecycle on EKS. AICR deployed the runtime components and collected the evidence, but the certified platform is NIM on EKS.

**`k8sConformanceUrl`:** For this submission, the certified product is **NVIDIA NIM on EKS**: an AI inference platform layered on top of Amazon EKS. NIM itself is not a Kubernetes distribution and does not have a separate entry in `cncf/k8s-conformance`, so we currently reference the underlying [EKS v1.35 Kubernetes conformance entry](https://github.com/cncf/k8s-conformance/tree/master/v1.35/eks) to establish the base cluster's Kubernetes conformance. If the AI Conformance WG prefers a different convention for layered products, we're happy to update this field accordingly.

## Next steps

- Follow-up submissions planned for NIM on GKE, AKS, and OKE
- AICR as validation tooling contribution to the WG community meetings (separate track)