### PR TITLE
ci: pin contents: read on landscape-update and validate

### DIFF
--- a/.github/workflows/landscape-update.yaml
+++ b/.github/workflows/landscape-update.yaml
@@ -13,6 +13,12 @@ on:
         required: true
         type: string
 
+# The cross-repo landscape PR update uses LANDSCAPE_GITHUB_TOKEN; the
+# default GITHUB_TOKEN is only used for checkout + a read-only `gh api`
+# call against /repos/*/commits/*/pulls.
+permissions:
+  contents: read
+
 jobs:
   update-landscape:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -6,6 +6,9 @@ on:
       - '**/PRODUCT.yaml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to read-only for both workflows:

- `landscape-update.yaml` — the cross-repo landscape PR is opened by `scripts/landscape.go` using `secrets.LANDSCAPE_GITHUB_TOKEN` (a separate PAT). The default token is only used for the checkout and a read-only `gh api repos/.../commits/.../pulls` lookup.
- `validate.yaml` — PR-only PRODUCT.yaml validation; no API writes.

YAML validated locally.