### PR TITLE
NVIDIA NIM on EKS AI Conformance for v1.35

### DIFF
--- a/v1.35/nvidia-nim-eks/PRODUCT.yaml
+++ b/v1.35/nvidia-nim-eks/PRODUCT.yaml
@@ -1,0 +1,314 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+metadata:
+  kubernetesVersion: v1.35
+  platformName: "NVIDIA NIM on EKS"
+  platformVersion: "1.8.3"
+  vendorName: "NVIDIA"
+  websiteUrl: "https://developer.nvidia.com/nim"
+  repoUrl: "https://github.com/NVIDIA/k8s-nim-operator"
+  documentationUrl: "https://docs.nvidia.com/nim/large-language-models/latest/deploy-helm.html"
+  productLogoUrl: "https://raw.githubusercontent.com/cncf/landscape/master/hosted_logos/nvidia-member.svg"
+  description: >-
+    NVIDIA NIM on EKS is a Kubernetes-based AI inference platform that deploys
+    and manages NVIDIA NIM microservices on Amazon EKS with GPU scheduling,
+    autoscaling, and Gateway API integration.
+  contactEmailAddress: "yuanchen97@gmail.com"
+  # NVIDIA NIM on EKS is a layered AI inference product on top of conformant
+  # Amazon EKS. Per the layered-product guidance in faq.md, this submission
+  # references the base distribution's Kubernetes Conformance entry. The
+  # required features are owned and re-tested on the layered platform; see
+  # README.md for the per-requirement layer ownership and the unique
+  # contributions of this layered product.
+  k8sConformanceUrl: "https://github.com/cncf/k8s-conformance/tree/master/v1.35/eks"
+
+spec:
+  accelerators:
+    - id: dra_support
+      description: "Support Dynamic Resource Allocation (DRA) APIs to enable more flexible and fine-grained resource requests beyond simple counts."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/dra-support.md"
+      notes: >-
+        Layer: base Amazon EKS v1.35 provides the upstream DRA API
+        (resource.k8s.io/v1) at GA. Layered runtime: NVIDIA DRA driver
+        (controller and kubelet-plugin) advertises individual H100 devices via
+        ResourceSlices and mediates allocation through ResourceClaims.
+        Contribution: layered driver implementation of DRA on EKS.
+
+        DRA API is enabled with DeviceClass, ResourceClaim, ResourceClaimTemplate,
+        and ResourceSlice resources available. The NVIDIA DRA driver advertises
+        individual H100 GPU devices via ResourceSlices with unique UUIDs, PCI
+        bus IDs, CUDA compute capability, and memory capacity. GPU allocation
+        to pods is mediated through ResourceClaims.
+    - id: driver_runtime_management
+      description: >-
+        Provide a verifiable mechanism for ensuring that compatible accelerator
+        drivers and corresponding container runtime configurations are correctly
+        installed and maintained on nodes with accelerators. Once the accelerator
+        supports exposing driver and runtime version information as part of DRA,
+        then the platform should use the DRA mechanism for verification.
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/dra-support.md"
+        - "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator.html"
+      notes: >-
+        Layer: layered runtime (NVIDIA GPU Operator). Contribution: SHOULD
+        addition — full driver/runtime/device-plugin lifecycle management with
+        per-node health verification.
+
+        GPU Operator manages the full driver and runtime lifecycle: driver
+        installation, container toolkit configuration, device plugin, and DRA
+        driver. The cluster evidence (dra-support.md) shows the DRA driver
+        ResourceSlices exposing per-device driver version and attributes used
+        for verification on the same cluster; the GPU Operator documentation
+        link describes the operator's driver/runtime/device-plugin lifecycle
+        and the nvidia-operator-validator that gates GPU-node readiness.
+    - id: gpu_sharing
+      description: >-
+        For accelerators that support static GPU sharing, provide well-defined
+        mechanisms for at least one GPU sharing strategy to improve utilization
+        for workloads that do not require a full dedicated GPU. If
+        hardware-level partitioning is supported, then these fractional GPU
+        resources should be exposed as schedulable resources. If software-based
+        sharing (e.g. time-slicing) is supported, then oversubscription of GPUs
+        should be allowed. Forward-looking: Once the accelerator supports
+        static GPU sharing as part of DRA, the platform should expose the DRA
+        mechanism to allow users to leverage static GPU sharing. Once the
+        accelerator supports dynamic GPU sharing as part of DRA and the
+        partitionable devices feature is GA, the platform should expose the DRA
+        mechanism to allow users to leverage dynamic GPU sharing.
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html"
+      notes: >-
+        Layer: layered runtime (NVIDIA GPU Operator with nvidia-mig-manager).
+        Contribution: SHOULD addition — hardware MIG partitioning plus
+        software time-slicing.
+
+        GPU Operator supports MIG (Multi-Instance GPU) partitioning for
+        hardware-level GPU sharing on supported accelerators (A100, H100). MIG
+        profiles are managed via the nvidia-mig-manager DaemonSet. Time-slicing
+        is also supported for software-based GPU sharing across workloads. As
+        partitionable devices in DRA reach GA, this layered product is
+        positioned to expose those mechanisms (see roadmap in README.md).
+    - id: virtualized_accelerator
+      description: >-
+        For accelerators that support virtualized accelerator technologies
+        (e.g. vGPU), provide well-defined mechanisms for these to be exposed
+        and managed, maintaining consistency with physical fractional GPUs.
+        Forward-looking: Once the accelerator supports virtualized accelerator
+        technologies as part of DRA, then the platform should use the DRA
+        mechanism.
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/install-gpu-operator-vgpu.html"
+      notes: >-
+        Layer: layered runtime (NVIDIA GPU Operator vGPU deployment).
+        Contribution: SHOULD addition — vGPU resources managed via the same
+        device plugin and DRA framework as physical GPUs.
+
+        GPU Operator supports vGPU deployments where the hypervisor exposes
+        virtual GPU devices to Kubernetes nodes. vGPU resources are managed
+        through the same device plugin and DRA framework as physical GPUs,
+        maintaining a consistent management experience.
+  networking:
+    - id: ai_inference
+      description: >-
+        Support the Kubernetes Gateway API with an implementation for advanced
+        traffic management for inference services, which enables capabilities
+        like weighted traffic splitting, header-based routing (for OpenAI
+        protocol headers), and optional integration with service meshes.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/inference-gateway.md"
+      notes: >-
+        Layer: layered runtime (kgateway with inference extension CRDs).
+        Contribution: MUST — meaningfully different variant of the Gateway API
+        requirement that adds inference-specific routing primitives
+        (InferencePool, InferenceModelRewrite, InferenceObjective) on top of
+        the base Gateway API.
+
+        kgateway controller is deployed with full Gateway API CRD support
+        (GatewayClass, Gateway, HTTPRoute, GRPCRoute, ReferenceGrant). Inference
+        extension CRDs (InferencePool, InferenceModelRewrite,
+        InferenceObjective) are registered. The evidence captures CRD
+        registration and an active inference gateway (GatewayClass
+        Accepted=True, Gateway Programmed=True), which together demonstrate the
+        platform provides the Gateway API and inference extension surfaces used
+        for advanced traffic-management capabilities such as weighted splitting,
+        header-based routing, and mesh integration.
+  schedulingOrchestration:
+    - id: gang_scheduling
+      description: >-
+        The platform must allow for the installation and successful operation of
+        at least one gang scheduling solution that ensures all-or-nothing
+        scheduling for distributed AI workloads (e.g. Kueue, Volcano, etc.) To
+        be conformant, the vendor must demonstrate that their platform can
+        successfully run at least one such solution.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/gang-scheduling.md"
+      notes: >-
+        Layer: layered runtime (KAI Scheduler). Contribution: MUST —
+        meaningfully different variant of gang scheduling (KAI Scheduler
+        instead of Kueue/Volcano), explicitly recognized in faq.md as an
+        example of a layered product's unique contribution.
+
+        KAI Scheduler is deployed with operator, scheduler, admission
+        controller, pod-grouper, and queue-controller components. PodGroup CRD
+        (scheduling.run.ai) is registered. Gang scheduling is verified by
+        deploying a PodGroup with minMember=2 and two GPU pods, demonstrating
+        all-or-nothing atomic scheduling.
+    - id: cluster_autoscaling
+      description: >-
+        If the platform provides a cluster autoscaler or an equivalent
+        mechanism, it must be able to scale up/down node groups containing
+        specific accelerator types based on pending pods requesting those
+        accelerators.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/cluster-autoscaling.md"
+      notes: >-
+        Layer: base Amazon EKS (Cluster Autoscaler on GPU Auto Scaling Group).
+        Contribution: matches the base — the layered product configures GPU
+        ASGs with the accelerator-aware tags Cluster Autoscaler requires.
+
+        EKS GPU Auto Scaling Group (p5.48xlarge, 8x H100 per node) is configured
+        with the accelerator-aware tags Cluster Autoscaler requires for
+        node-group discovery; the linked evidence captures the configuration
+        that enables accelerator-aware scaling.
+    - id: pod_autoscaling
+      description: >-
+        If the platform supports the HorizontalPodAutoscaler, it must function
+        correctly for pods utilizing accelerators. This includes the ability to
+        scale these Pods based on custom metrics relevant to AI/ML workloads.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/pod-autoscaling.md"
+      notes: >-
+        Layer: layered runtime (Prometheus adapter + DCGM custom metrics + HPA).
+        Contribution: MUST — wires GPU-specific custom metrics into the
+        Kubernetes custom metrics API so HPA can drive replica counts from
+        accelerator load, going beyond CPU/memory HPA.
+
+        Prometheus adapter exposes GPU custom metrics (gpu_utilization,
+        gpu_memory_used, gpu_power_usage) via the Kubernetes custom metrics API.
+        HPA is configured to target gpu_utilization at 50% threshold. Under GPU
+        stress testing (CUDA N-Body Simulation), HPA successfully scales
+        replicas from 1 to 2 pods when utilization exceeds the target, and
+        scales back down when GPU load is removed.
+  observability:
+    - id: accelerator_metrics
+      description: >-
+        For supported accelerator types, the platform must allow for the
+        installation and successful operation of at least one accelerator
+        metrics solution that exposes fine-grained performance metrics via a
+        standardized, machine-readable metrics endpoint. This must include a
+        core set of metrics for per-accelerator utilization and memory usage.
+        Additionally, other relevant metrics such as temperature, power draw,
+        and interconnect bandwidth should be exposed if the underlying hardware
+        or virtualization layer makes them available. The list of metrics should
+        align with emerging standards, such as OpenTelemetry metrics, to ensure
+        interoperability. The platform may provide a managed solution, but this
+        is not required for conformance.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/accelerator-metrics.md"
+      notes: >-
+        Layer: layered runtime (DCGM Exporter + Prometheus). Contribution:
+        MUST — DCGM Exporter is the layered component that exposes per-GPU
+        Prometheus metrics; the base EKS cluster does not produce these.
+
+        DCGM Exporter runs on GPU nodes exposing metrics at :9400/metrics in
+        Prometheus format. Per-GPU metrics include utilization, memory usage,
+        temperature (26-31C), and power draw (66-115W). Metrics include
+        pod/namespace/container labels for per-workload attribution. Prometheus
+        actively scrapes DCGM metrics via ServiceMonitor.
+    - id: ai_service_metrics
+      description: >-
+        Provide a monitoring system capable of discovering and collecting
+        metrics from workloads that expose them in a standard format (e.g.
+        Prometheus exposition format). This ensures easy integration for
+        collecting key metrics from common AI frameworks and servers.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/ai-service-metrics.md"
+      notes: >-
+        Layer: layered runtime (NIM inference microservice + Prometheus +
+        prometheus-adapter). Contribution: MUST — meaningfully different
+        variant that exposes AI-service-specific metrics (token throughput,
+        time-to-first-token, time-per-output-token) in addition to the
+        generic Prometheus exposition required by the spec.
+
+        NVIDIA NIM inference microservice exposes Prometheus-format metrics at
+        /v1/metrics including token throughput (prompt_tokens_total,
+        generation_tokens_total), request latency (time_to_first_token_seconds,
+        time_per_output_token_seconds), and model request counts. Prometheus
+        and prometheus-adapter are deployed for metrics collection and bridging
+        to the Kubernetes custom metrics API.
+  security:
+    - id: secure_accelerator_access
+      description: >-
+        Ensure that access to accelerators from within containers is properly
+        isolated and mediated by the Kubernetes resource management framework
+        (device plugin or DRA) and container runtime, preventing unauthorized
+        access or interference between workloads.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/secure-accelerator-access.md"
+      notes: >-
+        Layer: layered runtime (GPU Operator + DRA-mediated device access).
+        Contribution: MUST — GPU lifecycle management plus DRA-mediated device
+        isolation, verified end-to-end on the layered cluster.
+
+        GPU Operator manages all GPU lifecycle components (driver, device-plugin,
+        DCGM, toolkit, validator, MIG manager). 8x H100 GPUs are individually
+        advertised via ResourceSlices with DRA. Pod volumes contain only
+        kube-api-access projected tokens — no hostPath mounts to /dev/nvidia
+        devices. Device isolation is verified: a test pod requesting 1 GPU sees
+        only the single allocated device.
+  operator:
+    - id: robust_controller
+      description: >-
+        The platform must prove that at least one complex AI operator with a
+        CRD (e.g., Ray, Kubeflow) can be installed and functions reliably. This
+        includes verifying that the operator's pods run correctly, its webhooks
+        are operational, and its custom resources can be reconciled.
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/robust-operator.md"
+      notes: >-
+        Layer: layered runtime (NVIDIA NIM Operator). Contribution: MUST —
+        AI-inference-specific operator with 9 CRDs, admission webhook, and
+        end-to-end CR reconciliation evidence on the layered cluster.
+
+        NIM Operator validated: 9 CRDs (NIMService, NIMCache, NIMPipeline,
+        NIMBuild, NemoCustomizer, NemoDatastore, NemoEntityStore, NemoEvaluator,
+        NemoGuardrail), admission controller with webhook rejection test (invalid
+        NIMService correctly denied), NIMService CR reconciled into running
+        inference pod serving Llama 3.2 1B on H100 GPU.

--- a/v1.35/nvidia-nim-eks/README.md
+++ b/v1.35/nvidia-nim-eks/README.md
@@ -1,0 +1,61 @@
+# NVIDIA NIM on EKS
+
+[NVIDIA NIM](https://developer.nvidia.com/nim) on Amazon EKS is a Kubernetes-based AI inference platform that deploys and manages NVIDIA NIM microservices on EKS with GPU scheduling, autoscaling, and Gateway API integration. NIM microservice lifecycle is managed by the [NIM Operator](https://github.com/NVIDIA/k8s-nim-operator).
+
+## Conformance Submission
+
+- [PRODUCT.yaml](PRODUCT.yaml)
+
+## Layered Product
+
+NIM on EKS is a layered AI inference product on top of an existing Kubernetes-conformant distribution (Amazon EKS). This submission follows the layered-product guidance in [faq.md](../../faq.md):
+
+- **Base platform.** Amazon EKS v1.35 — Kubernetes conformance entry at [cncf/k8s-conformance/v1.35/eks](https://github.com/cncf/k8s-conformance/tree/master/v1.35/eks). EKS provides the prerequisite plain-Kubernetes conformance (control plane, networking, storage, accelerator enablement on managed node groups, the DRA API at GA in v1.35, and the Cluster Autoscaler integration).
+- **Layered runtime.** NVIDIA NIM Operator (`1.8.3`), KAI Scheduler, NVIDIA GPU Operator (driver, container toolkit, device plugin, DCGM Exporter, MIG manager, vGPU), NVIDIA DRA driver, kgateway with inference extension CRDs, Prometheus + prometheus-adapter.
+
+Per-requirement layer ownership is recorded in each entry's `notes` field in `PRODUCT.yaml`.
+
+### What this layered product uniquely contributes
+
+| Requirement | Contribution kind | Layered component |
+|---|---|---|
+| `gang_scheduling` | MUST — meaningfully different variant | KAI Scheduler (vs. Kueue/Volcano; called out in [faq.md](../../faq.md) as an example of a layered product's unique contribution) |
+| `ai_inference` | MUST — meaningfully different variant | kgateway with inference extension CRDs (InferencePool, InferenceModelRewrite, InferenceObjective) on top of the base Gateway API |
+| `ai_service_metrics` | MUST — meaningfully different variant | NIM inference microservice metrics (token throughput, time-to-first-token, time-per-output-token) on top of generic Prometheus scraping |
+| `robust_controller` | MUST — implements | NIM Operator (9 CRDs, admission webhook, NIMService reconcile) — an AI-inference-specific operator beyond the Ray/Kubeflow examples in the spec |
+| `accelerator_metrics` | MUST — implements | DCGM Exporter (the layered component that produces per-GPU Prometheus metrics) |
+| `pod_autoscaling` | MUST — implements | Prometheus adapter wiring GPU custom metrics into the K8s custom metrics API for HPA |
+| `dra_support` | MUST — implements | NVIDIA DRA driver advertising H100 devices via ResourceSlices |
+| `secure_accelerator_access` | MUST — implements | GPU Operator + DRA-mediated device isolation |
+| `driver_runtime_management` | SHOULD — addition | NVIDIA GPU Operator (full driver/runtime/device-plugin lifecycle) |
+| `gpu_sharing` | SHOULD — addition | GPU Operator MIG (A100/H100 hardware partitioning) + time-slicing |
+| `virtualized_accelerator` | SHOULD — addition | GPU Operator vGPU deployments |
+
+### Roadmap features
+
+These are on the AI Conformance roadmap and are anticipated for inclusion when the underlying platform mechanisms reach GA:
+
+- **Disaggregated inference** — [NVIDIA Dynamo](https://github.com/ai-dynamo/dynamo) for prefill/decode disaggregation. Called out in [faq.md](../../faq.md) as the canonical example of a meaningfully different variant of disaggregated inference (vs. llm-d). Will be submitted under the same layered-product framework when the requirement formalizes.
+- **DRA partitionable devices** — static and dynamic GPU sharing exposed through DRA once partitionable devices is GA. The layered NVIDIA DRA driver is already in place and positions this product to adopt the DRA mechanism without architectural changes.
+
+### Re-test confirmation
+
+Per [faq.md](../../faq.md): a layered product must re-test for full AI Conformance to confirm that the layered components did not break the base platform's existing Kubernetes Conformance behaviors. All 9 MUST requirements were evidenced on the layered cluster (EKS v1.35 with the runtime stack listed above), not on a bare EKS cluster, on 8x NVIDIA H100 80GB HBM3 GPUs running an NVIDIA NIM `Llama 3.2 1B` inference workload via `NIMService` CR. The 3 SHOULD requirements (`driver_runtime_management`, `gpu_sharing`, `virtualized_accelerator`) are implemented through the NVIDIA GPU Operator on the same cluster; `driver_runtime_management` has cluster evidence, and `gpu_sharing` / `virtualized_accelerator` are supported by GPU Operator documentation.
+
+## Evidence
+
+Full per-requirement evidence is hosted in the [AICR repository](https://github.com/NVIDIA/aicr/tree/main/docs/conformance/cncf/v1.35/nim-eks/evidence). Each `PRODUCT.yaml` entry links the corresponding evidence document.
+
+| # | Requirement | Layer / Component | Result | Evidence |
+|---|---|---|---|---|
+| 1 | `dra_support` | Layered: NVIDIA DRA driver | PASS | [dra-support.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/dra-support.md) |
+| 2 | `gang_scheduling` | Layered: KAI Scheduler | PASS | [gang-scheduling.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/gang-scheduling.md) |
+| 3 | `secure_accelerator_access` | Layered: GPU Operator + DRA | PASS | [secure-accelerator-access.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/secure-accelerator-access.md) |
+| 4 | `accelerator_metrics` | Layered: DCGM Exporter | PASS | [accelerator-metrics.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/accelerator-metrics.md) |
+| 5 | `ai_service_metrics` | Layered: NIM inference + Prometheus | PASS | [ai-service-metrics.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/ai-service-metrics.md) |
+| 6 | `ai_inference` | Layered: kgateway + inference CRDs | PASS | [inference-gateway.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/inference-gateway.md) |
+| 7 | `robust_controller` | Layered: NIM Operator | PASS | [robust-operator.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/robust-operator.md) |
+| 8 | `pod_autoscaling` | Layered: Prometheus adapter + HPA | PASS | [pod-autoscaling.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/pod-autoscaling.md) |
+| 9 | `cluster_autoscaling` | Base: EKS Cluster Autoscaler | PASS | [cluster-autoscaling.md](https://github.com/NVIDIA/aicr/blob/main/docs/conformance/cncf/v1.35/nim-eks/evidence/cluster-autoscaling.md) |
+
+All 9 MUST conformance requirements are **Implemented**. 3 SHOULD requirements (`driver_runtime_management`, `gpu_sharing`, `virtualized_accelerator`) are also Implemented.


### PR DESCRIPTION
### Pre-submission checklist

- [x] The submitter accepts and agrees to the [Certified Kubernetes AI Platform Conformance Program Terms and Conditions](https://github.com/cncf/k8s-ai-conformance/blob/main/terms-conditions/Certified_AI_Platform.md).
- [x] Product/project logo is provided in SVG (referenced via `productLogoUrl` to the CNCF landscape hosted logo).
- [x] Logo clearly states the product name and follows the participant logo [guidelines](https://github.com/cncf/landscape#logos).
- [x] `repoUrl` is included for the open-source NIM Operator (`github.com/NVIDIA/k8s-nim-operator`).

For a full list of requirements, see [Contents of the PR](https://github.com/cncf/k8s-ai-conformance/blob/main/instructions.md#contents-of-the-pr) and [Requirements](https://github.com/cncf/k8s-ai-conformance/blob/main/instructions.md#requirements).

This PR is filed as a **draft / WIP** for early review.

/hold

---

## NVIDIA NIM on EKS — resubmission

This is a clean resubmission following the layered-product guidance that landed in #95. The earlier PR #79 was reverted by #93 ahead of that guidance; this submission is built against current \`main\` and addresses the WG's feedback on layered products.

[NVIDIA NIM](https://developer.nvidia.com/nim) on Amazon EKS is a Kubernetes-based AI inference platform that deploys and manages NVIDIA NIM microservices on EKS with GPU scheduling, autoscaling, and Gateway API integration. NIM microservice lifecycle is managed by the [NIM Operator](https://github.com/NVIDIA/k8s-nim-operator). NIM is the certified product; AICR is the deployment and validation tooling used to bring up the runtime and collect evidence (analogous to sonobuoy for K8s conformance), not the certification target.

### How this submission addresses the layered-product guidance in #95

Per faq.md (the version merged in #95):

- **Base distribution.** Amazon EKS v1.35. \`k8sConformanceUrl\` references [cncf/k8s-conformance v1.35/eks](https://github.com/cncf/k8s-conformance/tree/master/v1.35/eks).
- **Per-requirement layer ownership.** Each entry in \`PRODUCT.yaml\` opens with a \`Layer:\` / \`Contribution:\` prelude naming the owning component and the contribution kind (matches base / MUST replacement / meaningfully different variant / SHOULD addition / roadmap). The README has the full ownership table.
- **Unique contributions.** The layered runtime contributes, among others, KAI Scheduler as a meaningfully different variant of gang scheduling (faq.md cites this example), kgateway with inference extension CRDs for \`ai_inference\`, NIM Operator for \`robust_controller\`, and NIM service metrics for \`ai_service_metrics\`.
- **Roadmap.** NVIDIA Dynamo for disaggregated inference (faq.md cites this as a canonical variant) and DRA partitionable devices for GPU sharing — captured in the README roadmap section.
- **Re-test on the layered cluster.** All 9 MUST requirements were evidenced on the layered EKS cluster (NIM Operator + KAI Scheduler + GPU Operator + DRA driver + kgateway + Prometheus stack), not on a bare EKS cluster, with 8x NVIDIA H100 80GB HBM3 GPUs running NVIDIA NIM Llama 3.2 1B via \`NIMService\` CR.

### Conformance evidence

| # | Requirement | Layer / Component | Result |
|---|---|---|---|
| 1 | \`dra_support\` | Layered: NVIDIA DRA driver | PASS |
| 2 | \`gang_scheduling\` | Layered: KAI Scheduler | PASS |
| 3 | \`secure_accelerator_access\` | Layered: GPU Operator + DRA | PASS |
| 4 | \`accelerator_metrics\` | Layered: DCGM Exporter | PASS |
| 5 | \`ai_service_metrics\` | Layered: NIM inference + Prometheus | PASS |
| 6 | \`ai_inference\` | Layered: kgateway + inference CRDs | PASS |
| 7 | \`robust_controller\` | Layered: NIM Operator | PASS |
| 8 | \`pod_autoscaling\` | Layered: Prometheus adapter + HPA | PASS |
| 9 | \`cluster_autoscaling\` | Base: EKS Cluster Autoscaler | PASS |

3 SHOULD requirements (\`driver_runtime_management\`, \`gpu_sharing\`, \`virtualized_accelerator\`) are also Implemented via the NVIDIA GPU Operator. Full evidence at [github.com/NVIDIA/aicr/.../v1.35/nim-eks/evidence](https://github.com/NVIDIA/aicr/tree/main/docs/conformance/cncf/v1.35/nim-eks/evidence).

### Follow-ups

NIM on GKE, AKS, and OKE will be submitted as separate per-cloud PRs using the same layered-product framework. NVIDIA Dynamo will be submitted as a separate layered-product PR once the disaggregated inference requirement formalizes.

cc @ritazh @jackfrancis @jeefy @terrytangyuan @janetkuo @puja108 @dims @mchmarny — this is the resubmission per the layered-product guidance you helped land in #95. Holding the PR (\`/hold\`) from day one to avoid the accidental-merge issue that hit #79.