### PR TITLE
ci(validate): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -6,6 +6,9 @@ on:
       - '**/PRODUCT.yaml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `validate` workflow runs k8s conformance validation only. No GitHub API writes, so workflow-level `contents: read` is the right cap.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.