### PR TITLE
Add OpenShift 4.22 AI Conformance submission for v1.35

### DIFF
--- a/v1.35/openshift/PRODUCT.yaml
+++ b/v1.35/openshift/PRODUCT.yaml
@@ -1,0 +1,115 @@
+# Kubernetes AI Conformance Checklist
+# Notes: This checklist is based on the Kubernetes AI Conformance document.
+# Participants should fill in the 'status', 'evidence', and 'notes' fields for each requirement.
+
+metadata:
+  kubernetesVersion: v1.35
+  platformName: "OpenShift Container Platform"
+  platformVersion: "4.22"
+  vendorName: "Red Hat"
+  websiteUrl: "https://www.redhat.com/en/technologies/cloud-computing/openshift"
+  documentationUrl: "https://docs.redhat.com/en/documentation/openshift_container_platform/4.22"
+  productLogoUrl: "https://www.redhat.com/rhdc/managed-files/Logo-Red_Hat-OpenShift-A-Standard-RGB.svg"
+  repoUrl: "https://github.com/openshift"
+  contactEmailAddress: "harpatil@redhat.com"
+  k8sConformanceUrl: "https://github.com/cncf/k8s-conformance/tree/master/v1.35/openshift"
+  description: "Red Hat OpenShift Container Platform is an enterprise-ready Kubernetes container platform with full-stack automated operations to manage hybrid cloud, multicloud, and edge deployments."
+
+spec:
+  accelerators:
+    - id: dra_support
+      description: "Support Dynamic Resource Allocation (DRA) APIs to enable more flexible and fine-grained resource requests beyond simple counts."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "dra-support.md"
+        - "https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html-single/nodes/index#nodes-pods-allocate-dra"
+      notes: "DRA v1 APIs (resource.k8s.io/v1) are enabled by default in OpenShift 4.22. The dra-support.md report shows GPUs advertised as attribute-rich devices via ResourceSlices and allocated to a workload through a ResourceClaim, using the NVIDIA DRA Driver for GPUs."
+    - id: driver_runtime_management
+      description: "Provide a verifiable mechanism for ensuring that compatible accelerator drivers and corresponding container runtime configurations are correctly installed and maintained on nodes with accelerators. Once the accelerator supports exposing driver and runtime version information as part of DRA, then the platform should use the DRA mechanism for verification."
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "driver-runtime-management.md"
+        - "https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/install-gpu-ocp.html"
+      notes: "The NVIDIA GPU Operator manages the full accelerator driver and container runtime lifecycle on OpenShift GPU nodes (driver container, NVIDIA Container Toolkit, and device plugin), and gates GPU-node readiness via the nvidia-operator-validator. The driver-runtime-management.md report shows the managed components, successful validation, and the driver and CUDA versions exposed through the DRA resource.k8s.io API."
+    - id: gpu_sharing
+      description: "For accelerators that support static GPU sharing, provide well-defined mechanisms for at least one GPU sharing strategy to improve utilization for workloads that do not require a full dedicated GPU. If hardware-level partitioning is supported, then these fractional GPU resources should be exposed as schedulable resources. If software-based sharing (e.g. time-slicing) is supported, then oversubscription of GPUs should be allowed. Forward-looking: Once the accelerator supports static GPU sharing as part of DRA, the platform should expose the DRA mechanism to allow users to leverage static GPU sharing. Once the accelerator supports dynamic GPU sharing as part of DRA and the partitionable devices feature is GA, the platform should expose the DRA mechanism to allow users to leverage dynamic GPU sharing."
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "gpu-sharing.md"
+        - "https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/time-slicing-gpus-in-openshift.html"
+        - "https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/mig-ocp.html"
+      notes: "OpenShift supports software-based GPU sharing via time-slicing and hardware-level partitioning via Multi-Instance GPU (MIG), both configured through the NVIDIA GPU Operator. The gpu-sharing.md report demonstrates time-slicing: two physical GPUs are oversubscribed to eight schedulable units and four workloads run concurrently sharing the two GPUs. MIG (on MIG-capable accelerators such as A100/H100) is configured through the same operator and is referenced in the NVIDIA OpenShift documentation."
+    - id: virtualized_accelerator
+      description: "For accelerators that support virtualized accelerator technologies (e.g. vGPU), provide well-defined mechanisms for these to be exposed and managed, maintaining consistency with physical fractional GPUs. Forward-looking: Once the accelerator supports virtualized accelerator technologies as part of DRA, then the platform should use the DRA mechanism."
+      level: SHOULD
+      status: "Implemented"
+      evidence:
+        - "https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/nvaie-with-ocp.html"
+      notes: "NVIDIA vGPU is supported on OpenShift through NVIDIA AI Enterprise with the NVIDIA GPU Operator, which exposes virtual GPU devices that are scheduled and managed consistently with physical GPUs."
+  networking:
+    - id: ai_inference
+      description: "Support the Kubernetes Gateway API with an implementation for advanced traffic management for inference services, which enables capabilities like weighted traffic splitting, header-based routing (for OpenAI protocol headers), and optional integration with service meshes."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/ingress_and_load_balancing/configuring-gateway-api"
+        - "https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/network_apis/gateway-gateway-networking-k8s-io-v1"
+      notes: "OpenShift 4.22 ships a built-in Gateway API implementation: creating a GatewayClass triggers the Ingress Operator to install a lightweight Istio control plane (based on Red Hat OpenShift Service Mesh) that serves Gateway API v1 resources (GatewayClass, Gateway, HTTPRoute), enabling weighted traffic splitting, header-based routing, and service mesh integration for inference traffic."
+  schedulingOrchestration:
+    - id: gang_scheduling
+      description: "The platform must allow for the installation and successful operation of at least one gang scheduling solution that ensures all-or-nothing scheduling for distributed AI workloads (e.g. Kueue, Volcano, etc.) To be conformant, the vendor must demonstrate that their platform can successfully run at least one such solution."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/ai_workloads/red-hat-build-of-kueue"
+      notes: "Red Hat build of Kueue enables gang admission for distributed AI workloads."
+    - id: cluster_autoscaling
+      description: "If the platform provides a cluster autoscaler or an equivalent mechanism, it must be able to scale up/down node groups containing specific accelerator types based on pending pods requesting those accelerators."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/machine_management/applying-autoscaling"
+        - "https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/hardware_accelerators/about-hardware-accelerators"
+      notes: "The OpenShift cluster autoscaler scales up/down MachineSets containing GPU accelerators based on pending pod resource requests."
+    - id: pod_autoscaling
+      description: "If the platform supports the HorizontalPodAutoscaler, it must function correctly for pods utilizing accelerators. This includes the ability to scale these Pods based on custom metrics relevant to AI/ML workloads."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/nodes/automatically-scaling-pods-with-the-custom-metrics-autoscaler-operator"
+      notes: ""
+  observability:
+    - id: accelerator_metrics
+      description: "For supported accelerator types, the platform must allow for the installation and successful operation of at least one accelerator metrics solution that exposes fine-grained performance metrics via a standardized, machine-readable metrics endpoint. This must include a core set of metrics for per-accelerator utilization and memory usage. Additionally, other relevant metrics such as temperature, power draw, and interconnect bandwidth should be exposed if the underlying hardware or virtualization layer makes them available. The list of metrics should align with emerging standards, such as OpenTelemetry metrics, to ensure interoperability. The platform may provide a managed solution, but this is not required for conformance."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/enable-gpu-monitoring-dashboard.html"
+        - "https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/hardware_accelerators/nvidia-gpu-architecture"
+      notes: "NVIDIA GPU Operator integrates DCGM-based monitoring, exposing GPU utilization, power consumption, temperature, and memory metrics via Prometheus endpoints."
+    - id: ai_service_metrics
+      description: "Provide a monitoring system capable of discovering and collecting metrics from workloads that expose them in a standard format (e.g. Prometheus exposition format). This ensures easy integration for collecting key metrics from common AI frameworks and servers."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://docs.redhat.com/en/documentation/openshift_container_platform/4.22/html/monitoring/index"
+      notes: "OpenShift provides a fully integrated monitoring system based on Prometheus that automatically discovers and scrapes metrics endpoints exposed by workloads in the standard Prometheus exposition format."
+  security:
+    - id: secure_accelerator_access
+      description: "Ensure that access to accelerators from within containers is properly isolated and mediated by the Kubernetes resource management framework (device plugin or DRA) and container runtime, preventing unauthorized access or interference between workloads."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "secure-accelerator-access.md"
+      notes: "The secure-accelerator-access.md report demonstrates that GPU access is mediated by the Kubernetes resource management framework and the NVIDIA container runtime, requires no privileged host access (pod runs under the restricted-v2 SCC), and confines a workload to only the single GPU it was granted on a two-GPU node."
+  operator:
+    - id: robust_controller
+      description: "The platform must prove that at least one complex AI operator with a CRD (e.g., Ray, Kubeflow) can be installed and functions reliably. This includes verifying that the operator's pods run correctly, its webhooks are operational, and its custom resources can be reconciled."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/3.3/html/working_with_distributed_workloads/running-kubeflow-trainerv2_distributed-workloads"
+      notes: "Kubeflow Trainer v2 operator with CRDs (TrainJob, TrainingRuntime, ClusterTrainingRuntime) runs on OpenShift via Red Hat OpenShift AI: enabling the Kubeflow Trainer component in the DataScienceCluster provides out-of-the-box ClusterTrainingRuntimes (e.g. torch-distributed) and a controller that reconciles TrainJob resources for distributed PyTorch training."

--- a/v1.35/openshift/dra-support.md
+++ b/v1.35/openshift/dra-support.md
@@ -1,0 +1,204 @@
+# DRA Support — Conformance Evidence
+
+**Requirement (`dra_support`, MUST):** Support Dynamic Resource Allocation (DRA) APIs
+to enable more flexible and fine-grained resource requests beyond simple counts.
+
+**Cluster:** OpenShift Container Platform 4.22.0 (GCP, `n1-standard-8`, 2x NVIDIA Tesla T4)
+**Kubernetes version:** v1.35.5
+**Date:** 2026-06-09
+
+## Summary
+
+OpenShift 4.22 ships the Dynamic Resource Allocation APIs (`resource.k8s.io/v1`) enabled
+by default. With the NVIDIA GPU Operator (v26.3.2) and the NVIDIA DRA Driver for GPUs
+(v25.12.0) installed, GPU devices are advertised through ResourceSlices with rich
+per-device attributes, and workloads allocate them through ResourceClaims. The sections
+below show the API availability, the advertised devices and their attributes, and a
+successful end-to-end allocation.
+
+## 1. DRA APIs available
+
+The DRA API group is served at GA (`resource.k8s.io/v1`):
+
+```
+$ oc api-resources --api-group=resource.k8s.io
+NAME                     SHORTNAMES   APIVERSION           NAMESPACED   KIND
+deviceclasses                         resource.k8s.io/v1   false        DeviceClass
+resourceclaims                        resource.k8s.io/v1   true         ResourceClaim
+resourceclaimtemplates                resource.k8s.io/v1   true         ResourceClaimTemplate
+resourceslices                        resource.k8s.io/v1   false        ResourceSlice
+```
+
+The GPU DRA driver registers its device classes:
+
+```
+$ oc get deviceclass
+NAME                  AGE
+gpu.nvidia.com        32m
+mig.nvidia.com        32m
+vfio.gpu.nvidia.com   32m
+```
+
+```
+$ oc get pods -n nvidia-dra-driver-gpu
+NAME                                         READY   STATUS    RESTARTS   AGE
+nvidia-dra-driver-gpu-kubelet-plugin-twk54   1/1     Running   0          32m
+```
+
+## 2. Devices advertised with fine-grained attributes
+
+Each physical GPU is advertised as an individual device in a ResourceSlice. Beyond a
+simple count, every device exposes structured attributes (architecture, driver and CUDA
+versions, compute capability, memory capacity, and a unique UUID) that can be used for
+attribute-based selection in a ResourceClaim:
+
+```
+$ oc get resourceslices
+NAME                                                   NODE                              DRIVER           POOL                              AGE
+harpatil4220c-g9kfm-gpu-c-rd8r8-gpu.nvidia.com-wvrlc   harpatil4220c-g9kfm-gpu-c-rd8r8   gpu.nvidia.com   harpatil4220c-g9kfm-gpu-c-rd8r8   32m
+```
+
+```
+$ oc get resourceslices -o yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceSlice
+metadata:
+  name: harpatil4220c-g9kfm-gpu-c-rd8r8-gpu.nvidia.com-wvrlc
+  ...
+spec:
+  driver: gpu.nvidia.com
+  nodeName: harpatil4220c-g9kfm-gpu-c-rd8r8
+  pool:
+    generation: 1
+    name: harpatil4220c-g9kfm-gpu-c-rd8r8
+    resourceSliceCount: 1
+  devices:
+  - name: gpu-0
+    attributes:
+      addressingMode: {string: HMM}
+      architecture: {string: Turing}
+      brand: {string: Nvidia}
+      cudaComputeCapability: {version: 7.5.0}
+      cudaDriverVersion: {version: 13.0.0}
+      driverVersion: {version: 580.126.20}
+      productName: {string: Tesla T4}
+      resource.kubernetes.io/pciBusID: {string: "0000:00:04.0"}
+      resource.kubernetes.io/pcieRoot: {string: pci0000:00}
+      type: {string: gpu}
+      uuid: {string: GPU-da96f367-6e47-8dc4-fd29-4f0b97b9f174}
+    capacity:
+      memory: {value: 15Gi}
+  - name: gpu-1
+    attributes:
+      addressingMode: {string: HMM}
+      architecture: {string: Turing}
+      brand: {string: Nvidia}
+      cudaComputeCapability: {version: 7.5.0}
+      cudaDriverVersion: {version: 13.0.0}
+      driverVersion: {version: 580.126.20}
+      productName: {string: Tesla T4}
+      resource.kubernetes.io/pciBusID: {string: "0000:00:05.0"}
+      resource.kubernetes.io/pcieRoot: {string: pci0000:00}
+      type: {string: gpu}
+      uuid: {string: GPU-204349eb-0405-e927-278b-8804172f1be3}
+    capacity:
+      memory: {value: 15Gi}
+```
+
+> Output condensed: `metadata` is elided and attribute maps are shown in flow style
+> for readability; all device attributes are listed.
+
+## 3. Allocation through a ResourceClaim
+
+The following manifest requests one GPU of device class `gpu.nvidia.com` through a
+ResourceClaim and runs a container that verifies device access:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dra-test
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: gpu-claim
+  namespace: dra-test
+spec:
+  devices:
+    requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dra-gpu-test
+  namespace: dra-test
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  resourceClaims:
+    - name: gpu
+      resourceClaimName: gpu-claim
+  containers:
+    - name: gpu-test
+      image: nvidia/cuda:12.9.0-base-ubuntu24.04
+      command: ["bash", "-c", "ls -l /dev/nvidia* && echo '---' && nvidia-smi -L && echo 'DRA GPU allocation successful'"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+      resources:
+        claims:
+          - name: gpu
+```
+
+```
+$ oc apply -f dra-gpu-test.yaml
+namespace/dra-test created
+resourceclaim.resource.k8s.io/gpu-claim created
+pod/dra-gpu-test created
+```
+
+```
+$ oc get pod dra-gpu-test -n dra-test
+NAME           READY   STATUS      RESTARTS   AGE
+dra-gpu-test   0/1     Completed   0          19m
+```
+
+```
+$ oc logs dra-gpu-test -n dra-test
+crw-rw-rw-. 1 1000760000 root 195, 254 Jun  9 18:35 /dev/nvidia-modeset
+crw-rw-rw-. 1 1000760000 root 511,   0 Jun  9 18:35 /dev/nvidia-uvm
+crw-rw-rw-. 1 1000760000 root 511,   1 Jun  9 18:35 /dev/nvidia-uvm-tools
+crw-rw-rw-. 1 1000760000 root 195,   0 Jun  9 18:35 /dev/nvidia0
+crw-rw-rw-. 1 1000760000 root 195, 255 Jun  9 18:35 /dev/nvidiactl
+---
+GPU 0: Tesla T4 (UUID: GPU-da96f367-6e47-8dc4-fd29-4f0b97b9f174)
+DRA GPU allocation successful
+```
+
+The allocated device (`GPU-da96f367-...`) corresponds to `gpu-0` advertised in the
+ResourceSlice above.
+
+> The ResourceClaim returns to an unallocated state once the consuming pod completes, as
+> the DRA controller releases the claimed device automatically.
+
+## Result
+
+**PASS.** OpenShift 4.22 supports the DRA APIs (`resource.k8s.io/v1`), advertises GPUs as
+attribute-rich devices through ResourceSlices, and successfully allocates them to
+workloads through ResourceClaims — satisfying the `dra_support` requirement.
+
+## Cleanup
+
+```
+$ oc delete ns dra-test
+```

--- a/v1.35/openshift/driver-runtime-management.md
+++ b/v1.35/openshift/driver-runtime-management.md
@@ -1,0 +1,116 @@
+# Driver and Runtime Management — Conformance Evidence
+
+**Requirement (`driver_runtime_management`, SHOULD):** Provide a verifiable mechanism for
+ensuring that compatible accelerator drivers and corresponding container runtime
+configurations are correctly installed and maintained on nodes with accelerators. Once
+the accelerator supports exposing driver and runtime version information as part of DRA,
+then the platform should use the DRA mechanism for verification.
+
+**Cluster:** OpenShift Container Platform 4.22.0 (GCP, `n1-standard-8`, 2x NVIDIA Tesla T4)
+**Kubernetes version:** v1.35.5
+**Date:** 2026-06-09
+
+## Summary
+
+On OpenShift 4.22 the NVIDIA GPU Operator installs and maintains the full accelerator
+driver and container-runtime stack on GPU nodes, and gates node readiness on a set of
+validations. In addition, the NVIDIA DRA Driver for GPUs publishes the installed driver
+and CUDA versions as device attributes in ResourceSlices, providing a DRA-native,
+machine-readable mechanism for verifying driver and runtime state.
+
+## 1. Driver and runtime components are installed and maintained
+
+The GPU Operator deploys and reconciles the driver, the NVIDIA Container Toolkit (runtime
+configuration), and the device plugin as DaemonSets bound to GPU nodes:
+
+```
+$ oc get ds -n nvidia-gpu-operator
+NAME                                      DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   AGE
+nvidia-container-toolkit-daemonset        1         1         1       1            1           60m
+nvidia-device-plugin-daemonset            1         1         1       1            1           60m
+nvidia-driver-daemonset-9.8.20260520-0    1         1         1       1            1           60m
+nvidia-operator-validator                 1         1         1       1            1           60m
+```
+
+```
+$ oc get pods -n nvidia-gpu-operator
+NAME                                           READY   STATUS      RESTARTS   AGE
+nvidia-container-toolkit-daemonset-7bqvx       1/1     Running     0          60m
+nvidia-cuda-validator-brppm                    0/1     Completed   0          56m
+nvidia-driver-daemonset-9.8.20260520-0-kmbqm   2/2     Running     0          61m
+nvidia-operator-validator-tzwql                1/1     Running     0          60m
+```
+
+> Output abridged to the driver/runtime components relevant to this requirement (and
+> the `NODE SELECTOR` column is omitted for width). The operator also deploys
+> `gpu-feature-discovery`, `nvidia-dcgm`, `nvidia-dcgm-exporter`, `nvidia-mig-manager`,
+> `nvidia-device-plugin-mps-control-daemon`, and `nvidia-node-status-exporter`
+> DaemonSets in the same namespace; the full pod listing appears in
+> [secure-accelerator-access.md](secure-accelerator-access.md).
+
+The driver DaemonSet is selected onto nodes by OS version
+(`feature.node.kubernetes.io/system-os_release.OSTREE_VERSION=9.8.20260520-0`), ensuring
+the driver build matches the node's RHCOS version — i.e. the operator maintains a
+*compatible* driver for each node.
+
+## 2. Installed driver version
+
+The driver loaded on the node, queried from the driver container:
+
+```
+$ oc exec -n nvidia-gpu-operator nvidia-driver-daemonset-9.8.20260520-0-kmbqm \
+    -c nvidia-driver-ctr -- nvidia-smi --query-gpu=name,driver_version,index --format=csv
+name, driver_version, index
+Tesla T4, 580.126.20, 0
+Tesla T4, 580.126.20, 1
+```
+
+## 3. Readiness is gated on validation
+
+The `nvidia-operator-validator` verifies the driver, toolkit, CUDA, and device-plugin are
+correctly installed before the node is marked ready for GPU workloads:
+
+```
+$ oc get pods -n nvidia-gpu-operator -l app=nvidia-operator-validator
+NAME                              READY   STATUS    RESTARTS   AGE
+nvidia-operator-validator-tzwql   1/1     Running   0          60m
+
+$ oc logs -n nvidia-gpu-operator -l app=nvidia-operator-validator -c nvidia-operator-validator
+all validations are successful
+```
+
+The `nvidia-cuda-validator` (Completed, above) additionally confirms the runtime can
+launch a CUDA workload end to end.
+
+## 4. Driver and CUDA versions exposed through DRA
+
+The NVIDIA DRA Driver for GPUs advertises the driver version, CUDA driver version, and
+compute capability as device attributes in each ResourceSlice. This provides the
+DRA-native verification mechanism described in the requirement — driver and runtime
+information is queryable through the `resource.k8s.io` API:
+
+```
+$ oc get resourceslices -o yaml
+...
+  devices:
+  - name: gpu-0
+    attributes:
+      architecture: {string: Turing}
+      cudaComputeCapability: {version: 7.5.0}
+      cudaDriverVersion: {version: 13.0.0}
+      driverVersion: {version: 580.126.20}
+      productName: {string: Tesla T4}
+...
+```
+
+The `driverVersion` (`580.126.20`) reported through DRA matches the driver reported by
+`nvidia-smi` on the node, confirming the DRA attributes are an accurate source of truth
+for verification.
+
+## Result
+
+**PASS.** OpenShift 4.22, via the NVIDIA GPU Operator, installs and maintains a compatible
+driver and container-runtime configuration on GPU nodes and gates node readiness on
+successful validation. Driver and CUDA versions are additionally exposed through the
+DRA `resource.k8s.io` API, satisfying the `driver_runtime_management` requirement
+including its forward-looking DRA-based verification mechanism.

--- a/v1.35/openshift/gpu-sharing.md
+++ b/v1.35/openshift/gpu-sharing.md
@@ -1,0 +1,148 @@
+# GPU Sharing — Conformance Evidence
+
+**Requirement (`gpu_sharing`, SHOULD):** For accelerators that support static GPU
+sharing, provide well-defined mechanisms for at least one GPU sharing strategy to improve
+utilization for workloads that do not require a full dedicated GPU. If hardware-level
+partitioning is supported, then these fractional GPU resources should be exposed as
+schedulable resources. If software-based sharing (e.g. time-slicing) is supported, then
+oversubscription of GPUs should be allowed.
+
+**Cluster:** OpenShift Container Platform 4.22.0 (GCP, `n1-standard-8`, 2x NVIDIA Tesla T4)
+**Kubernetes version:** v1.35.5
+**Date:** 2026-06-09
+
+## Summary
+
+OpenShift 4.22, via the NVIDIA GPU Operator, supports software-based GPU sharing through
+time-slicing, which allows oversubscription of physical GPUs. This evidence configures
+time-slicing with 4 replicas per GPU, shows the node advertising 8 schedulable GPUs from
+2 physical devices, and demonstrates four workloads concurrently sharing the two physical
+GPUs.
+
+> The two T4 GPUs in this cluster are not MIG-capable, so hardware-level partitioning
+> (MIG) is not exercised here; the requirement is satisfied by demonstrating one sharing
+> strategy. MIG on MIG-capable accelerators (e.g. A100/H100) is configured through the
+> same GPU Operator and is referenced in the NVIDIA OpenShift documentation.
+
+## 1. Enable time-slicing
+
+A device-plugin configuration requesting 4 time-sliced replicas per GPU:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: time-slicing-config
+  namespace: nvidia-gpu-operator
+data:
+  any: |-
+    version: v1
+    flags:
+      migStrategy: none
+    sharing:
+      timeSlicing:
+        resources:
+        - name: nvidia.com/gpu
+          replicas: 4
+```
+
+The GPU Operator's ClusterPolicy is pointed at the configuration, after which the device
+plugin re-rolls automatically:
+
+```
+$ oc patch clusterpolicy gpu-cluster-policy --type merge \
+    -p '{"spec":{"devicePlugin":{"config":{"name":"time-slicing-config","default":"any"}}}}'
+clusterpolicy.nvidia.com/gpu-cluster-policy patched
+```
+
+## 2. Oversubscription: 2 physical GPUs advertised as 8 schedulable
+
+Before enabling time-slicing the node advertised one schedulable unit per physical GPU:
+
+```
+$ oc get node harpatil4220c-g9kfm-gpu-c-rd8r8 -o jsonpath='{.status.capacity.nvidia\.com/gpu}'
+2
+```
+
+After enabling time-slicing (4 replicas x 2 physical GPUs) it advertises 8:
+
+```
+$ oc get node harpatil4220c-g9kfm-gpu-c-rd8r8 -o jsonpath='{.status.capacity.nvidia\.com/gpu}'
+8
+```
+
+## 3. Workloads share the physical GPUs
+
+A Deployment of 4 replicas, each requesting `nvidia.com/gpu: 1`, is scheduled onto the
+node — more GPU-requesting pods than there are physical GPUs:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ts-share
+  namespace: gpu-sharing-test
+spec:
+  replicas: 4
+  selector:
+    matchLabels: {app: ts-share}
+  template:
+    metadata:
+      labels: {app: ts-share}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: {type: RuntimeDefault}
+      containers:
+        - name: cuda
+          image: nvidia/cuda:12.9.0-base-ubuntu24.04
+          command: ["bash","-c","nvidia-smi -L; sleep 3600"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities: {drop: ["ALL"]}
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+```
+
+All four pods are admitted and running on the single two-GPU node:
+
+```
+$ oc get pods -n gpu-sharing-test -o wide
+NAME                        READY   STATUS    RESTARTS   AGE   IP            NODE                              ...
+ts-share-6774cbb654-btf44   1/1     Running   0          11s   10.130.2.38   harpatil4220c-g9kfm-gpu-c-rd8r8   ...
+ts-share-6774cbb654-cplqx   1/1     Running   0          11s   10.130.2.36   harpatil4220c-g9kfm-gpu-c-rd8r8   ...
+ts-share-6774cbb654-jwfs6   1/1     Running   0          11s   10.130.2.37   harpatil4220c-g9kfm-gpu-c-rd8r8   ...
+ts-share-6774cbb654-zkxn6   1/1     Running   0          11s   10.130.2.39   harpatil4220c-g9kfm-gpu-c-rd8r8   ...
+```
+
+Each pod reports the physical GPU it was assigned. Across the four pods only the two
+physical GPU UUIDs appear — each physical GPU is shared by two pods:
+
+```
+$ for p in $(oc get pods -n gpu-sharing-test -o name); do oc logs -n gpu-sharing-test $p; done
+GPU 0: Tesla T4 (UUID: GPU-da96f367-6e47-8dc4-fd29-4f0b97b9f174)
+GPU 0: Tesla T4 (UUID: GPU-da96f367-6e47-8dc4-fd29-4f0b97b9f174)
+GPU 0: Tesla T4 (UUID: GPU-204349eb-0405-e927-278b-8804172f1be3)
+GPU 0: Tesla T4 (UUID: GPU-204349eb-0405-e927-278b-8804172f1be3)
+
+# UUID tally across the 4 pods:
+   2 GPU-204349eb-0405-e927-278b-8804172f1be3
+   2 GPU-da96f367-6e47-8dc4-fd29-4f0b97b9f174
+```
+
+## Result
+
+**PASS.** OpenShift 4.22 supports software-based GPU sharing via time-slicing through the
+NVIDIA GPU Operator. Two physical GPUs are oversubscribed to 8 schedulable units, and
+four workloads run concurrently while sharing the two physical GPUs (two workloads per
+GPU) — satisfying the `gpu_sharing` requirement.
+
+## Cleanup
+
+```
+$ oc delete ns gpu-sharing-test
+$ oc patch clusterpolicy gpu-cluster-policy --type json \
+    -p '[{"op":"remove","path":"/spec/devicePlugin/config"}]'
+$ oc delete configmap time-slicing-config -n nvidia-gpu-operator
+```

--- a/v1.35/openshift/secure-accelerator-access.md
+++ b/v1.35/openshift/secure-accelerator-access.md
@@ -1,0 +1,168 @@
+# Secure Accelerator Access — Conformance Evidence
+
+**Requirement (`secure_accelerator_access`, MUST):** Ensure that access to accelerators
+from within containers is properly isolated and mediated by the Kubernetes resource
+management framework (device plugin or DRA) and container runtime, preventing
+unauthorized access or interference between workloads.
+
+**Cluster:** OpenShift Container Platform 4.22.0 (GCP, `n1-standard-8`, 2x NVIDIA Tesla T4)
+**Kubernetes version:** v1.35.5
+**Date:** 2026-06-09
+
+## Summary
+
+On OpenShift 4.22, GPU access is granted exclusively through the Kubernetes resource
+management framework and the NVIDIA container runtime. A workload receives a device only
+by claiming it (here via a DRA ResourceClaim); the container runtime then injects exactly
+the claimed device. This evidence shows that (1) accelerator access is mediated by the
+GPU Operator stack and the resource framework, and (2) a workload granted one GPU is
+isolated from the other GPU on the same node, with no path to unauthorized access.
+
+## 1. Accelerator access is mediated by the platform
+
+The NVIDIA GPU Operator manages the driver, container runtime configuration, and device
+lifecycle, and reports a healthy state:
+
+```
+$ oc get clusterpolicy gpu-cluster-policy
+NAME                 STATUS   AGE
+gpu-cluster-policy   ready    44m
+```
+
+```
+$ oc get pods -n nvidia-gpu-operator
+NAME                                           READY   STATUS      RESTARTS      AGE
+gpu-feature-discovery-rdg5s                    1/1     Running     0             41m
+gpu-operator-85656dd79d-2zt64                  1/1     Running     0             44m
+nvidia-container-toolkit-daemonset-7bqvx       1/1     Running     0             41m
+nvidia-cuda-validator-brppm                    0/1     Completed   0             37m
+nvidia-dcgm-exporter-2pkvm                     1/1     Running     3 (36m ago)   41m
+nvidia-dcgm-m9bhs                              1/1     Running     0             41m
+nvidia-device-plugin-daemonset-fmhdb           1/1     Running     0             41m
+nvidia-driver-daemonset-9.8.20260520-0-kmbqm   2/2     Running     0             41m
+nvidia-node-status-exporter-hxgtq              1/1     Running     0             41m
+nvidia-operator-validator-tzwql                1/1     Running     0             41m
+```
+
+Access is brokered through the resource management framework: a pod must reference a
+ResourceClaim to obtain a device, and the device is injected by the NVIDIA container
+runtime rather than mounted directly from the host. The isolation test pod below
+declares its GPU through `resourceClaims` and carries no host device mounts:
+
+```
+$ oc get pod isolation-test -n secure-access-test -o jsonpath='{.spec.resourceClaims}'
+[{"name":"gpu","resourceClaimName":"isolated-gpu"}]
+```
+
+```
+$ oc get pod isolation-test -n secure-access-test -o json | jq '[.spec.volumes[] | select(.hostPath)] | length'
+0
+```
+
+The pod is admitted under OpenShift's default, most restrictive Security Context
+Constraint, confirming no elevated host privileges are required for accelerator access:
+
+```
+$ oc get pod isolation-test -n secure-access-test -o jsonpath='{.metadata.annotations.openshift\.io/scc}'
+restricted-v2
+```
+
+## 2. Workload isolation
+
+The GPU node hosts two Tesla T4 GPUs. The following workload claims a single GPU and
+inspects which devices are visible inside the container:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: secure-access-test
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: isolated-gpu
+  namespace: secure-access-test
+spec:
+  devices:
+    requests:
+      - name: gpu
+        exactly:
+          deviceClassName: gpu.nvidia.com
+          allocationMode: ExactCount
+          count: 1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: isolation-test
+  namespace: secure-access-test
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  resourceClaims:
+    - name: gpu
+      resourceClaimName: isolated-gpu
+  containers:
+    - name: gpu-test
+      image: nvidia/cuda:12.9.0-base-ubuntu24.04
+      command: ["bash","-c","echo '=== Visible NVIDIA devices ==='; ls -l /dev/nvidia*; echo; echo '=== nvidia-smi output ==='; nvidia-smi -L; echo; echo '=== GPU count visible to container ==='; nvidia-smi -L | wc -l; echo 'Secure accelerator access test completed'"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: ["ALL"]
+      resources:
+        claims:
+          - name: gpu
+```
+
+```
+$ oc apply -f secure-accelerator-access.yaml
+namespace/secure-access-test created
+resourceclaim.resource.k8s.io/isolated-gpu created
+pod/isolation-test created
+```
+
+```
+$ oc get pod isolation-test -n secure-access-test
+NAME             READY   STATUS      RESTARTS   AGE
+isolation-test   0/1     Completed   0          19m
+```
+
+```
+$ oc logs isolation-test -n secure-access-test
+=== Visible NVIDIA devices ===
+crw-rw-rw-. 1 1000770000 root 195, 254 Jun  9 18:35 /dev/nvidia-modeset
+crw-rw-rw-. 1 1000770000 root 511,   0 Jun  9 18:35 /dev/nvidia-uvm
+crw-rw-rw-. 1 1000770000 root 511,   1 Jun  9 18:35 /dev/nvidia-uvm-tools
+crw-rw-rw-. 1 1000770000 root 195,   0 Jun  9 18:35 /dev/nvidia0
+crw-rw-rw-. 1 1000770000 root 195, 255 Jun  9 18:35 /dev/nvidiactl
+
+=== nvidia-smi output ===
+GPU 0: Tesla T4 (UUID: GPU-da96f367-6e47-8dc4-fd29-4f0b97b9f174)
+
+=== GPU count visible to container ===
+1
+Secure accelerator access test completed
+```
+
+Although the node has two GPUs, the container can see and access only the single GPU it
+was granted (`/dev/nvidia0`, `GPU-da96f367-...`). The second GPU (`GPU-204349eb-...`) is
+not present in the container's device namespace, so the workload has no way to reach or
+interfere with accelerators allocated to other workloads.
+
+## Result
+
+**PASS.** Accelerator access on OpenShift 4.22 is mediated by the Kubernetes resource
+management framework and the NVIDIA container runtime, requires no privileged host
+access, and confines each workload to exactly the device it was granted — satisfying the
+`secure_accelerator_access` requirement.
+
+## Cleanup
+
+```
+$ oc delete ns secure-access-test
+```


### PR DESCRIPTION
This PR adds the Kubernetes AI Conformance self-assessment for **Red Hat OpenShift Container Platform 4.22** (Kubernetes v1.35).

