### PR TITLE
Identify URL validator with an honest bot User-Agent

### DIFF
--- a/scripts/validate.go
+++ b/scripts/validate.go
@@ -18,7 +18,7 @@ import (
 
 const landscapeURL = "https://raw.githubusercontent.com/cncf/landscape/master/landscape.yml"
 
-const userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+const userAgent = "CNCF-K8s-AI-Conformance-Validator/1.0 (+https://github.com/cncf/k8s-ai-conformance)"
 
 // LandscapeData represents the top-level structure of the CNCF landscape YAML
 type LandscapeData struct {
@@ -400,8 +400,8 @@ func validateURL(urlStr string) error {
 	return nil
 }
 
-// doRequest creates an HTTP request with browser-like headers to avoid being
-// blocked by WAFs/bot-protection that reject Go's default User-Agent.
+// doRequest creates an HTTP request that honestly identifies this validator,
+// so vendors whose docs sit behind a WAF can allowlist it by User-Agent.
 func doRequest(client *http.Client, method, url string) (*http.Response, error) {
 	req, err := http.NewRequest(method, url, nil)
 	if err != nil {


### PR DESCRIPTION
## Problem

The URL validator in `scripts/validate.go` sends a spoofed desktop Chrome User-Agent to "avoid being blocked by WAFs". Impersonating a browser from a GitHub runner IP is exactly the pattern modern bot-protection detects: Akamai's browser-impersonator rule on docs.redhat.com flags it and returns 403 for every evidence URL in the OpenShift v1.35 submission (#109), blocking certification. See #110 for details.

We confirmed with the docs.redhat.com edge/WAF team that the rule was triggered specifically because the traffic claims to be a real browser while clearly not being one (`BOT-BROWSER-IMPERSONATOR`). They will not weaken bot protection for anonymous traffic, but they **can allowlist a well-known bot User-Agent** — and suggested this project adopt one.

## Change

Replace the fake Chrome UA with a transparent one that identifies this project and links back to it:

```
CNCF-K8s-AI-Conformance-Validator/1.0 (+https://github.com/cncf/k8s-ai-conformance)
```

This follows the convention used by legitimate crawlers (Googlebot, GitHub-Camo, etc.) and gives every vendor — not just Red Hat — a stable token to allowlist if their docs sit behind a WAF, instead of the validator trying to sneak past bot protection.

## Verification

Ran the validator with the new User-Agent against existing v1.35 submissions whose evidence URLs span major vendor doc sites:

- `v1.35/eks/PRODUCT.yaml` — validation successful (docs.aws.amazon.com)
- `v1.35/aks/PRODUCT.yaml` — validation successful (learn.microsoft.com)
- `v1.35/nvidia-nim-eks/PRODUCT.yaml` — validation successful (docs.nvidia.com)

(`v1.35/gke` fails on main and on this branch identically, on a vendorName/landscape mismatch unrelated to URL checking; its URL checks pass.)

Fixes #110