### PR TITLE
fix: ignore 429 status code for evidence URL validation

### DIFF
--- a/scripts/validate.go
+++ b/scripts/validate.go
@@ -383,7 +383,7 @@ func validateURL(urlStr string) error {
 	}
 	// Try HEAD first
 	resp, err := doRequest(client, http.MethodHead, urlStr)
-	if err == nil && resp.StatusCode < 400 {
+	if err == nil && (resp.StatusCode < 400 || resp.StatusCode == http.StatusTooManyRequests) {
 		resp.Body.Close()
 		return nil
 	}
@@ -394,7 +394,7 @@ func validateURL(urlStr string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode >= 400 {
+	if resp.StatusCode >= 400 && resp.StatusCode != http.StatusTooManyRequests {
 		return fmt.Errorf("status code %d", resp.StatusCode)
 	}
 	return nil


### PR DESCRIPTION
Fixes validation failures due to false positives from 429 Too Many Requests, which currently block PRs (e.g., #115) when documentation sites implement rate limiting against CI runners. Resolves #130.