### PR TITLE
docs: update guidance for automated tests and hybrid verification

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,8 @@
 
 * [ ] Does the `vendorName` exactly match your organization's name in the [CNCF Landscape](https://landscape.cncf.io/members)?
 
+* [ ] (For v1.37+ submissions) If using automated test results (recommended for applicable requirements), did you include the test artifacts (`e2e.log`, `junit.xml`, or `results.json`)?
+
 
 For a full list of requirements, please refer to these sections of the docs: [Contents of the PR](https://github.com/cncf/k8s-ai-conformance/blob/main/instructions.md#contents-of-the-pr), and [Requirements](https://github.com/cncf/k8s-ai-conformance/blob/main/instructions.md#requirements).
 

--- a/README.md
+++ b/README.md
@@ -60,20 +60,20 @@ Most submissions are a completed checklist plus links to public evidence—think
 
 For the canonical reference tests and example implementations, see the upstream [AI Conformance test suite](https://github.com/kubernetes-sigs/ai-conformance/tree/main/test).
 
-## Hybrid Verification Submission (v1.37+)
+#### Hybrid Verification Submission (v1.37+)
 
 Starting with v1.37, we support a hybrid verification approach that combines automated test results with manual attestation:
 
-1.  **Automated Tests**: For requirements with automated tests (e.g., Secure Accelerator Access, Gang Scheduling), run the test suite and include the output files (`e2e.log`, `junit.xml`) in your submission PR.
+1.  **Automated Tests**: For requirements with automated tests (e.g., Secure Accelerator Access, Gang Scheduling), it is **recommended** that you run the upstream [AI Conformance test suite](https://github.com/kubernetes-sigs/ai-conformance/tree/main/test) and include the generated test artifacts (`e2e.log`, `junit.xml`, or `results.json`) in your submission PR.
 2.  **Manual Attestation**: For requirements without automated tests, continue to provide documentation or reference URLs in the `evidence` field of the checklist YAML.
 
-Reference your automated test results in the checklist YAML using the `file://` scheme or relative paths to your submitted test artifacts.
-The automated tests are not required for certification yet, but they provide additional confidence in your platform's conformance.
+Reference your automated test results in the checklist YAML using relative file paths or the `file://` scheme.
+Starting with v1.37, it is recommended that any requirement covered by an automated test is verified using this test suite.
 
 #### The certification process
 
 1. **Prepare** - Review the [certification requirements](terms-conditions/Certified_AI_Platform.md) and make sure your platform meets them
-2. **Document** - Fill out the conformance checklist and gather evidence (documentation, test results, etc.)
+2. **Document & Test** - Fill out the conformance checklist, run automated tests if applicable, and gather evidence (documentation, test results, etc.)
 3. **Submit** - Create a pull request with your submission to the https://github.com/cncf/k8s-ai-conformance repo.
 4. **Review** - CNCF reviews your submission (typically takes up to 10 business days)
 
@@ -81,12 +81,13 @@ The automated tests are not required for certification yet, but they provide add
 
 - A completed conformance checklist (YAML file)
 - Public documentation showing how your platform meets each requirement
+- (Recommended for v1.37+) Automated test artifacts (`e2e.log`, `junit.xml`, or `results.json`) for requirements covered by automated tests
 - Your product logo in vector format (SVG, EPS, or AI)
 - Proof of Kubernetes conformance
 
-**Note:** Today, certification is based on self-assessment. Automated conformance tests are planned for 2026.
+**Note:** Starting with v1.37, automated tests are available and recommended for applicable requirements. For earlier versions or requirements without automated tests, certification is based on documentation-backed self-assessment.
 
-For detailed instructions on what to include, see [instructions.md](instructions.md#contents-of-the-pr).
+For detailed instructions on running tests and what to include, see [instructions.md](instructions.md#hybrid-verification--automated-tests-v137).
 
 ---
 
@@ -100,7 +101,7 @@ The program is a community-led effort to establish a vendor-neutral baseline for
 |------|----------------|
 | **Documentation** | Help improve guides, add examples, fix typos, clarify confusing parts |
 | **Research** | Identify requirements for new AI workload types (especially agentic workloads) |
-| **Testing** | Help develop automated conformance tests |
+| **Testing** | Help develop automated conformance tests in [kubernetes-sigs/ai-conformance](https://github.com/kubernetes-sigs/ai-conformance/tree/main/test) |
 | **Discussion** | Participate in project meetings and design discussions |
 
 #### How to get involved
@@ -115,8 +116,8 @@ The program is a community-led effort to establish a vendor-neutral baseline for
 
 ```mermaid
 flowchart TD
-    A[Platform must be Kubernetes Conformant] --> B[Complete self-assessment checklist]
-    B --> C[Gather evidence and documentation]
+    A[Platform must be Kubernetes Conformant] --> B[Complete checklist & run automated tests]
+    B --> C[Gather evidence and test artifacts]
     C --> D[Submit pull request]
     D --> E[CNCF reviews submission]
     E -->|Approved| F[Certified for 1 year]

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,15 @@ Each `AIConformance-1.xx.yaml` file contains the conformance requirements for th
 - All `MUST` requirements must be fulfilled with documented evidence to achieve conformance
 - All `SHOULD` requirements are recommended but optional
 
+## Hybrid Verification Submission (v1.37+)
+
+Starting with v1.37, we support a hybrid verification approach that combines automated test results with manual attestation:
+
+1.  **Automated Tests**: For requirements with automated tests (e.g., Secure Accelerator Access, Gang Scheduling, Cluster Autoscaling), it is **recommended** that you run the upstream [AI Conformance test suite](https://github.com/kubernetes-sigs/ai-conformance/tree/main/test) and include the output files (`e2e.log`, `junit.xml`, or `results.json`) in your submission PR.
+2.  **Manual Attestation**: For requirements without automated tests, continue to provide documentation or reference URLs in the `evidence` field of the checklist YAML.
+
+Reference your automated test results in the checklist YAML using the `file://` scheme or relative paths to your submitted test artifacts. See [instructions.md](../instructions.md#hybrid-verification--automated-tests-v137) for details on running tests and generating evidence.
+
 ## Release Freeze
 
 The `AIConformance-1.xx.yaml` files are finalized at Kubernetes Release Freeze and won't change after that point.

--- a/faq.md
+++ b/faq.md
@@ -15,7 +15,7 @@ The primary goals of the program are to:
 
 ### Will there be AI conformance tests?
 
-Automated conformance tests are planned for 2026. Currently, certification is based on self-assessment using a conformance checklist.
+Automated conformance tests are now available in the upstream [AI Conformance test suite](https://github.com/kubernetes-sigs/ai-conformance/tree/main/test). Starting with Kubernetes v1.37, we support a hybrid verification approach where automated tests are recommended for requirements that have them (e.g., Secure Accelerator Access, Gang Scheduling, Cluster Autoscaling), combined with manual attestation and documentation for the remaining requirements.
 
 ### Why are some requirements conditional?
 
@@ -24,6 +24,8 @@ The context of the requirements doesn’t always apply to all platforms. For exa
 ### Does a "Not Applicable" (N/A) status mean platforms can skip requirements?
 
 No. The justification for an N/A status cannot be "we don’t support this feature," but rather an explanation of why the requirement's context doesn't apply to the platform's environment.
+
+For automated tests, platforms may skip or opt out of specific sub-tests (using test-specific flags or `-run` filtering) if the corresponding requirement is N/A, provided a clear justification is given in the checklist notes.
 
 ### Is self-certification per product or per company?
 

--- a/instructions.md
+++ b/instructions.md
@@ -17,10 +17,12 @@ product.  Examples would be `gke` or `openshift`.
 
 ### Contents of the PR
 
-You must submit the completed self assesment manifest file for the relevant major/minor version of Kubernetes. 
+You must submit the completed self assessment manifest file for the relevant major/minor version of Kubernetes in a subdirectory named after your product (`$dir`), along with test artifacts if applicable:
 
 ```
-vX.Y/$dir/PRODUCT.yaml: See below.
+vX.Y/$dir/PRODUCT.yaml: (Required) See below.
+vX.Y/$dir/e2e.log: (Recommended for v1.37+) Raw test execution log.
+vX.Y/$dir/junit.xml: (Recommended for v1.37+) Machine-readable test report (or results.json).
 ```
 
 #### PRODUCT.yaml
@@ -59,12 +61,70 @@ metadata:
   k8s_conformance_url: https://github.com/cncf/k8s-conformance/tree/master/v1.34/turbo-encabulator
 ```
 
+### Hybrid Verification & Automated Tests (v1.37+)
+
+Starting with Kubernetes v1.37, the AI Conformance program supports a **hybrid verification approach** that combines automated test execution with manual attestation:
+
+- **Automated Tests**: Requirements covered by automated tests (e.g., Secure Accelerator Access, Gang Scheduling, Cluster Autoscaling) are **recommended** to be verified by running the upstream [AI Conformance test suite](https://github.com/kubernetes-sigs/ai-conformance/tree/main/test). The generated test output files (`e2e.log`, `junit.xml`, or `results.json`) should be included in your submission directory (`v1.37/$dir/`).
+- **Manual Attestation**: Requirements without automated tests continue to be verified via public documentation or reference URLs in the `evidence` field of your `PRODUCT.yaml`.
+
+#### Running Tests & Generating Test Artifacts
+
+Run the conformance tests against your cluster and generate the necessary artifacts for your submission:
+
+```bash
+# 1. Capture full output log (e2e.log)
+go test -v ./test | tee e2e.log
+
+# 2. Generate machine-readable JSON (results.json)
+go test -v ./test -json > results.json
+
+# 3. Generate JUnit XML report (junit.xml)
+# Option A: Using gotestsum (Recommended - runs via go run)
+go run gotest.tools/gotestsum@latest --junitfile junit.xml -- ./test
+# Option B: Using go-junit-report
+go test -v ./test 2>&1 | go run github.com/jstemmer/go-junit-report/v2@latest > junit.xml
+```
+
+For test execution details, vendor flags, and prerequisites, refer to the upstream [test documentation](https://github.com/kubernetes-sigs/ai-conformance/tree/main/test).
+
+#### Referencing Test Results in `PRODUCT.yaml`
+
+Link your generated test artifacts under the `evidence` field for the corresponding requirement using relative file paths or the `file://` scheme:
+
+```yaml
+    - id: secure_accelerator_access
+      description: "Ensure that access to accelerators from within containers is properly isolated..."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "e2e.log"
+        - "junit.xml"
+```
+or:
+```yaml
+    - id: secure_accelerator_access
+      description: "Ensure that access to accelerators from within containers is properly isolated..."
+      level: MUST
+      status: "Implemented"
+      evidence:
+        - "file://v1.37/$dir/junit.xml#TestSecureAcceleratorAccess"
+        - "file://v1.37/$dir/e2e.log"
+```
+
+#### Opting Out (N/A Requirements)
+
+If a specific requirement is not applicable to your platform (i.e., you answered "N/A" in the conformance checklist), you may skip or opt out of that specific sub-test:
+- Use test-specific flags if available (for example, leave `-autoscaler-node-pool-label` unset to skip the cluster autoscaling test).
+- Use the `go test -run <regex>` flag to execute only applicable tests.
+- When submitting your results, ensure you provide a clear explanation and justification in the `notes` field of `PRODUCT.yaml` for why the requirement is considered N/A.
+
 ### Requirements
 
 The self conformance file must be submitted without adjustments or changes in spec to the fields `id, description, level`.
 The fields `status, evidence, and notes` need to be filled if the `level` is `MUST`.
 
-To reach conformance all `MUST` spec fields need to be addressed and the evidence needs to be publicly reachable. 
+To reach conformance, all `MUST` spec fields need to be addressed. Evidence can be publicly reachable documentation URLs or submitted test artifacts (such as `e2e.log` and `junit.xml` in your submission directory). 
 
 
 ## Amendment for Private Review


### PR DESCRIPTION
This PR updates repository documentation and instructions to reflect the availability of automated tests and the hybrid verification approach starting with Kubernetes v1.37, referencing changes from kubernetes-sigs/ai-conformance#83 and kubernetes-sigs/ai-conformance#87.

### Summary of Changes

- **`instructions.md`**:
  - Added a dedicated section on **Hybrid Verification & Automated Tests (v1.37+)** explaining the hybrid verification workflow.
  - Added instructions and command examples for running the test suite and capturing test artifacts (`e2e.log`, `results.json`, and `junit.xml`).
  - Added examples of linking test artifacts under `evidence` in `PRODUCT.yaml`.
  - Clarified handling of Not Applicable (N/A) requirements and opting out of automated tests via flags or test filters.
  - Updated `Contents of the PR` and `Requirements` sections to cover test artifacts alongside documentation evidence.

- **`README.md`**:
  - Clarified under **For Vendors** that automated tests from the upstream [AI Conformance test suite](https://github.com/kubernetes-sigs/ai-conformance/tree/main/test) are recommended for covered requirements starting in v1.37.
  - Updated the certification process and submission contents to include test artifacts for v1.37+.
  - Updated the outdated note regarding automated tests availability.
  - Updated the contributor testing entry to link directly to the upstream test directory.
  - Updated the certification flowchart to reflect automated testing.

- **`faq.md`**:
  - Updated the answer to *"Will there be AI conformance tests?"* to announce the upstream test suite and explain hybrid verification.
  - Clarified how N/A requirements apply to automated tests.

- **`docs/README.md`**:
  - Added the **Hybrid Verification Submission (v1.37+)** section with links to execution details in `instructions.md`.

- **`.github/PULL_REQUEST_TEMPLATE.md`**:
  - Added a checklist item prompting submitters for automated test artifacts on v1.37+ submissions.